### PR TITLE
[feat] 은행 CRUD API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum BaseCode {
-    STATUS_OK("STATUS_OK_200", HttpStatus.OK, "서버가 정상적으로 동작 중입니다.");
+    STATUS_OK("STATUS_OK_200", HttpStatus.OK, "서버가 정상적으로 동작 중입니다."),
+
+    // 은행
+    BANK_NOT_FOUND("BANK_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 은행을 찾을 수 없습니다.");
+
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -9,7 +9,14 @@ import org.springframework.http.HttpStatus;
 public enum BaseCode {
     STATUS_OK("STATUS_OK_200", HttpStatus.OK, "서버가 정상적으로 동작 중입니다."),
 
-    // 은행
+    // 은행 - 성공
+    BANK_CREATE_SUCCESS("BANK_CREATE_SUCCESS_201", HttpStatus.CREATED, "은행이 성공적으로 생성되었습니다."),
+    BANK_READ_SUCCESS("BANK_READ_SUCCESS_200", HttpStatus.OK, "은행 정보를 성공적으로 조회했습니다."),
+    BANK_LIST_SUCCESS("BANK_LIST_SUCCESS_200", HttpStatus.OK, "은행 목록을 성공적으로 조회했습니다."),
+    BANK_UPDATE_SUCCESS("BANK_UPDATE_SUCCESS_200", HttpStatus.OK, "은행 정보가 성공적으로 수정되었습니다."),
+    BANK_DELETE_SUCCESS("BANK_DELETE_SUCCESS_200", HttpStatus.OK, "은행이 성공적으로 삭제되었습니다."),
+
+    // 은행 - 예외
     BANK_NOT_FOUND("BANK_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 은행을 찾을 수 없습니다.");
 
 

--- a/src/main/java/com/ureca/snac/common/advice/GlobalAdvice.java
+++ b/src/main/java/com/ureca/snac/common/advice/GlobalAdvice.java
@@ -1,0 +1,22 @@
+package com.ureca.snac.common.advice;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.common.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalAdvice {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<?>> handleBusinessException(BusinessException e) {
+        log.warn("Exception: ", e);
+
+        return ResponseEntity
+                .status(e.getBaseCode().getStatus())
+                .body(ApiResponse.ok(e.getBaseCode()));
+    }
+}

--- a/src/main/java/com/ureca/snac/common/exception/BusinessException.java
+++ b/src/main/java/com/ureca/snac/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.ureca.snac.common.exception;
+
+import com.ureca.snac.common.BaseCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final BaseCode baseCode;
+
+    public BusinessException(BaseCode baseCode) {
+        super((baseCode.getMessage()));
+        this.baseCode = baseCode;
+    }
+}

--- a/src/main/java/com/ureca/snac/finance/controller/BankController.java
+++ b/src/main/java/com/ureca/snac/finance/controller/BankController.java
@@ -1,0 +1,59 @@
+package com.ureca.snac.finance.controller;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.finance.controller.request.CreateBankRequest;
+import com.ureca.snac.finance.controller.request.UpdateBankRequest;
+import com.ureca.snac.finance.service.BankService;
+import com.ureca.snac.finance.service.response.BankResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.ureca.snac.common.BaseCode.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/banks")
+public class BankController {
+
+    private final BankService bankService;
+
+    @GetMapping("/{bankId}")
+    public ResponseEntity<ApiResponse<BankResponse>> getBank(@PathVariable("bankId") Long bankId) {
+        return ResponseEntity.ok(ApiResponse.of(BANK_READ_SUCCESS, bankService.getBankById(bankId)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BankResponse>>> getAllBanks() {
+        return ResponseEntity.ok(ApiResponse.of(BANK_LIST_SUCCESS, bankService.getAllBanks()));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> createBank(@Validated @RequestBody CreateBankRequest createBankRequest) {
+        bankService.createBank(createBankRequest);
+
+        return ResponseEntity
+                .status(BANK_CREATE_SUCCESS.getStatus())
+                .body(ApiResponse.ok(BANK_CREATE_SUCCESS));
+    }
+
+    @DeleteMapping("/{bankId}")
+    public ResponseEntity<ApiResponse<?>> deleteBank(@PathVariable("bankId") Long bankId) {
+        bankService.deleteBank(bankId);
+
+        return ResponseEntity.ok(ApiResponse.ok(BANK_DELETE_SUCCESS));
+    }
+
+    @PatchMapping("/{bankId}")
+    public ResponseEntity<ApiResponse<?>> updateBank(@PathVariable("bankId") Long bankId,
+                                                     @Validated @RequestBody UpdateBankRequest updateBankRequest) {
+        bankService.updateBank(bankId, updateBankRequest);
+
+        return ResponseEntity.ok(ApiResponse.ok(BANK_UPDATE_SUCCESS));
+    }
+}

--- a/src/main/java/com/ureca/snac/finance/controller/request/CreateBankRequest.java
+++ b/src/main/java/com/ureca/snac/finance/controller/request/CreateBankRequest.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.finance.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class CreateBankRequest {
+    @NotBlank
+    private String name;
+}

--- a/src/main/java/com/ureca/snac/finance/controller/request/UpdateBankRequest.java
+++ b/src/main/java/com/ureca/snac/finance/controller/request/UpdateBankRequest.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.finance.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UpdateBankRequest {
+    @NotBlank
+    private String name;
+}

--- a/src/main/java/com/ureca/snac/finance/entity/Bank.java
+++ b/src/main/java/com/ureca/snac/finance/entity/Bank.java
@@ -19,4 +19,12 @@ public class Bank extends BaseTimeEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    public Bank(String name) {
+        this.name = name;
+    }
+
+    public void update(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/ureca/snac/finance/entity/Bank.java
+++ b/src/main/java/com/ureca/snac/finance/entity/Bank.java
@@ -1,0 +1,22 @@
+package com.ureca.snac.finance.entity;
+
+import com.ureca.snac.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "bank")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bank extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "bank_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+}

--- a/src/main/java/com/ureca/snac/finance/exception/BankNotFoundException.java
+++ b/src/main/java/com/ureca/snac/finance/exception/BankNotFoundException.java
@@ -1,0 +1,17 @@
+package com.ureca.snac.finance.exception;
+
+import com.ureca.snac.common.BaseCode;
+import lombok.Getter;
+
+import java.util.NoSuchElementException;
+
+@Getter
+public class BankNotFoundException extends NoSuchElementException {
+
+    private final BaseCode baseCode;
+
+    public BankNotFoundException(BaseCode baseCode) {
+        super(baseCode.getMessage());
+        this.baseCode = baseCode;
+    }
+}

--- a/src/main/java/com/ureca/snac/finance/exception/BankNotFoundException.java
+++ b/src/main/java/com/ureca/snac/finance/exception/BankNotFoundException.java
@@ -1,17 +1,14 @@
 package com.ureca.snac.finance.exception;
 
-import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.common.exception.BusinessException;
 import lombok.Getter;
 
-import java.util.NoSuchElementException;
+import static com.ureca.snac.common.BaseCode.BANK_NOT_FOUND;
 
 @Getter
-public class BankNotFoundException extends NoSuchElementException {
+public class BankNotFoundException extends BusinessException {
 
-    private final BaseCode baseCode;
-
-    public BankNotFoundException(BaseCode baseCode) {
-        super(baseCode.getMessage());
-        this.baseCode = baseCode;
+    public BankNotFoundException() {
+        super(BANK_NOT_FOUND);
     }
 }

--- a/src/main/java/com/ureca/snac/finance/repository/BankRepository.java
+++ b/src/main/java/com/ureca/snac/finance/repository/BankRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.snac.finance.repository;
+
+import com.ureca.snac.finance.entity.Bank;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankRepository extends JpaRepository<Bank, Long> {
+}

--- a/src/main/java/com/ureca/snac/finance/service/BankService.java
+++ b/src/main/java/com/ureca/snac/finance/service/BankService.java
@@ -1,0 +1,20 @@
+package com.ureca.snac.finance.service;
+
+import com.ureca.snac.finance.controller.request.CreateBankRequest;
+import com.ureca.snac.finance.controller.request.UpdateBankRequest;
+import com.ureca.snac.finance.service.response.BankResponse;
+
+import java.util.List;
+
+public interface BankService {
+
+    Long createBank(CreateBankRequest createBankRequest);
+
+    BankResponse getBankById(Long bankId);
+
+    List<BankResponse> getAllBanks();
+
+    void updateBank(Long bankId, UpdateBankRequest updateBankRequest);
+
+    void deleteBank(Long bankId);
+}

--- a/src/main/java/com/ureca/snac/finance/service/BankServiceImpl.java
+++ b/src/main/java/com/ureca/snac/finance/service/BankServiceImpl.java
@@ -24,6 +24,7 @@ public class BankServiceImpl implements BankService{
     private final BankRepository bankRepository;
 
     @Override
+    @Transactional
     public Long createBank(CreateBankRequest createBankRequest) {
         Bank savedBank = bankRepository.save(new Bank(createBankRequest.getName()));
 
@@ -46,6 +47,7 @@ public class BankServiceImpl implements BankService{
     }
 
     @Override
+    @Transactional
     public void updateBank(Long bankId, UpdateBankRequest updateBankRequest) {
         Bank bank = bankRepository
                 .findById(bankId)
@@ -55,6 +57,7 @@ public class BankServiceImpl implements BankService{
     }
 
     @Override
+    @Transactional
     public void deleteBank(Long bankId) {
         bankRepository.deleteById(bankId);
     }

--- a/src/main/java/com/ureca/snac/finance/service/BankServiceImpl.java
+++ b/src/main/java/com/ureca/snac/finance/service/BankServiceImpl.java
@@ -13,8 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.ureca.snac.common.BaseCode.BANK_NOT_FOUND;
-
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -35,7 +33,7 @@ public class BankServiceImpl implements BankService{
     public BankResponse getBankById(Long bankId) {
         return bankRepository.findById(bankId)
                 .map(BankResponse::from)
-                .orElseThrow(() -> new BankNotFoundException(BANK_NOT_FOUND));
+                .orElseThrow(BankNotFoundException::new);
     }
 
     @Override
@@ -51,7 +49,7 @@ public class BankServiceImpl implements BankService{
     public void updateBank(Long bankId, UpdateBankRequest updateBankRequest) {
         Bank bank = bankRepository
                 .findById(bankId)
-                .orElseThrow(() -> new BankNotFoundException(BANK_NOT_FOUND));
+                .orElseThrow(BankNotFoundException::new);
 
         bank.update(updateBankRequest.getName());
     }

--- a/src/main/java/com/ureca/snac/finance/service/BankServiceImpl.java
+++ b/src/main/java/com/ureca/snac/finance/service/BankServiceImpl.java
@@ -1,0 +1,61 @@
+package com.ureca.snac.finance.service;
+
+import com.ureca.snac.finance.controller.request.CreateBankRequest;
+import com.ureca.snac.finance.controller.request.UpdateBankRequest;
+import com.ureca.snac.finance.entity.Bank;
+import com.ureca.snac.finance.exception.BankNotFoundException;
+import com.ureca.snac.finance.repository.BankRepository;
+import com.ureca.snac.finance.service.response.BankResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.ureca.snac.common.BaseCode.BANK_NOT_FOUND;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BankServiceImpl implements BankService{
+
+    private final BankRepository bankRepository;
+
+    @Override
+    public Long createBank(CreateBankRequest createBankRequest) {
+        Bank savedBank = bankRepository.save(new Bank(createBankRequest.getName()));
+
+        return savedBank.getId();
+    }
+
+    @Override
+    public BankResponse getBankById(Long bankId) {
+        return bankRepository.findById(bankId)
+                .map(BankResponse::from)
+                .orElseThrow(() -> new BankNotFoundException(BANK_NOT_FOUND));
+    }
+
+    @Override
+    public List<BankResponse> getAllBanks() {
+        return bankRepository.findAll()
+                .stream()
+                .map(BankResponse::from)
+                .toList();
+    }
+
+    @Override
+    public void updateBank(Long bankId, UpdateBankRequest updateBankRequest) {
+        Bank bank = bankRepository
+                .findById(bankId)
+                .orElseThrow(() -> new BankNotFoundException(BANK_NOT_FOUND));
+
+        bank.update(updateBankRequest.getName());
+    }
+
+    @Override
+    public void deleteBank(Long bankId) {
+        bankRepository.deleteById(bankId);
+    }
+}

--- a/src/main/java/com/ureca/snac/finance/service/response/BankResponse.java
+++ b/src/main/java/com/ureca/snac/finance/service/response/BankResponse.java
@@ -1,0 +1,21 @@
+package com.ureca.snac.finance.service.response;
+
+import com.ureca.snac.finance.entity.Bank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BankResponse {
+
+    private Long id;
+    private String name;
+
+    public static BankResponse from(Bank bank) {
+        return new BankResponse(
+                bank.getId(),
+                bank.getName()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 변경 사항

1. 은행(Bank) 엔티티에 대한 CRUD API 구현
2. 예외 (BankNotFoundException, BusinessException) 추가

## 🔍 변경 사항 세부 설명

- POST /api/banks: 은행 생성 API 구현
- GET /api/banks/{bankId}: 단일 은행 조회 API 구현
- GET /api/banks: 은행 목록 조회 API 구현
- PATCH /api/banks/{bankId}: 은행 정보 수정 API 구현
- DELETE /api/banks/{bankId}: 은행 삭제 API 구현
- BankNotFoundException 커스텀 예외 추가 및 전역 핸들러 처리

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 