### PR TITLE
feat: AWS SNS를 이용한 인증번호 발송(SNS 연동) 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns'
+    
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/ureca/snac/auth/config/SnsConfig.java
+++ b/src/main/java/com/ureca/snac/auth/config/SnsConfig.java
@@ -1,0 +1,33 @@
+package com.ureca.snac.auth.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+@Getter
+@Configuration
+public class SnsConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String awsAccessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String awsSecretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String awsRegion;
+
+    @Bean
+    public SnsClient snsClient() {
+        return SnsClient.builder()
+                .region(Region.of(awsRegion))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(awsAccessKey, awsSecretKey)))
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/snac/auth/controller/JoinController.java
+++ b/src/main/java/com/ureca/snac/auth/controller/JoinController.java
@@ -1,24 +1,25 @@
 package com.ureca.snac.auth.controller;
 
-import com.ureca.snac.auth.dto.JoinDto;
-import com.ureca.snac.auth.service.JoinService;
+import com.ureca.snac.auth.dto.request.JoinRequest;
+import com.ureca.snac.auth.service.JoinServiceImpl;
 import com.ureca.snac.common.ApiResponse;
-import com.ureca.snac.common.BaseCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.ureca.snac.common.BaseCode.*;
 
 @RestController
 @RequiredArgsConstructor
 public class JoinController {
 
-    private final JoinService joinService;
+    private final JoinServiceImpl joinServiceImpl;
 
     @PostMapping("/api/join")
-    public ApiResponse<Void> joinProcess(@RequestBody JoinDto joinDto) {
-
-        joinService.joinProcess(joinDto);
-        return ApiResponse.ok(BaseCode.USER_SIGNUP_SUCCESS);
+    public ResponseEntity<ApiResponse<Void>> joinProcess(@RequestBody JoinRequest joinRequest) {
+        joinServiceImpl.joinProcess(joinRequest);
+        return ResponseEntity.ok(ApiResponse.ok(USER_SIGNUP_SUCCESS));
     }
 }

--- a/src/main/java/com/ureca/snac/auth/controller/SnsController.java
+++ b/src/main/java/com/ureca/snac/auth/controller/SnsController.java
@@ -1,0 +1,27 @@
+package com.ureca.snac.auth.controller;
+
+import com.ureca.snac.auth.dto.request.PhoneRequest;
+import com.ureca.snac.auth.dto.response.VerificationCodeResponse;
+import com.ureca.snac.auth.service.SnsService;
+import com.ureca.snac.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.ureca.snac.common.BaseCode.*;
+
+@RestController
+@RequiredArgsConstructor
+public class SnsController {
+
+    private final SnsService snsService;
+
+    @PostMapping("/api/send-verification-code")
+    public ResponseEntity<ApiResponse<VerificationCodeResponse>> sendVerificationCode(@RequestBody PhoneRequest dto) {
+        String code = snsService.sendVerificationCode(dto.getPhone());
+        VerificationCodeResponse response = new VerificationCodeResponse(code);
+        return ResponseEntity.ok(ApiResponse.of(SMS_VERIFICATION_SENT, response));
+    }
+}

--- a/src/main/java/com/ureca/snac/auth/dto/request/JoinRequest.java
+++ b/src/main/java/com/ureca/snac/auth/dto/request/JoinRequest.java
@@ -1,4 +1,4 @@
-package com.ureca.snac.auth.dto;
+package com.ureca.snac.auth.dto.request;
 
 import lombok.*;
 
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class JoinDto {
+public class JoinRequest {
     private String email;
     private String password;
     private String name;

--- a/src/main/java/com/ureca/snac/auth/dto/request/PhoneRequest.java
+++ b/src/main/java/com/ureca/snac/auth/dto/request/PhoneRequest.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PhoneRequest {
+    private String phone;
+}

--- a/src/main/java/com/ureca/snac/auth/dto/response/VerificationCodeResponse.java
+++ b/src/main/java/com/ureca/snac/auth/dto/response/VerificationCodeResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VerificationCodeResponse {
+    private String verificationCode;
+}

--- a/src/main/java/com/ureca/snac/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/com/ureca/snac/auth/exception/AuthExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.auth.exception;
 
 import com.ureca.snac.common.ApiResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -8,7 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class AuthExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
-    public ApiResponse<Void> handleBusinessException(BusinessException e) {
-        return ApiResponse.of(e.getBaseCode(),null);
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        return ResponseEntity.ok(ApiResponse.of(e.getBaseCode(),null));
     }
 }

--- a/src/main/java/com/ureca/snac/auth/exception/SmsSendFailedException.java
+++ b/src/main/java/com/ureca/snac/auth/exception/SmsSendFailedException.java
@@ -1,0 +1,14 @@
+package com.ureca.snac.auth.exception;
+
+import com.ureca.snac.common.BaseCode;
+import lombok.Getter;
+
+@Getter
+public class SmsSendFailedException extends RuntimeException {
+    private final BaseCode baseCode;
+
+    public SmsSendFailedException(BaseCode baseCode) {
+        super(baseCode.getMessage());
+        this.baseCode = baseCode;
+    }
+}

--- a/src/main/java/com/ureca/snac/auth/service/JoinService.java
+++ b/src/main/java/com/ureca/snac/auth/service/JoinService.java
@@ -1,43 +1,8 @@
 package com.ureca.snac.auth.service;
 
-import com.ureca.snac.auth.dto.JoinDto;
-import com.ureca.snac.auth.exception.BusinessException;
-import com.ureca.snac.auth.repository.AuthRepository;
-import com.ureca.snac.common.BaseCode;
-import com.ureca.snac.member.Member;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.ureca.snac.auth.dto.request.JoinRequest;
 
-import static com.ureca.snac.member.Activated.*;
-import static com.ureca.snac.member.Role.*;
+public interface JoinService {
 
-@Service
-@RequiredArgsConstructor
-public class JoinService {
-
-    private final AuthRepository authRepository;
-    private final BCryptPasswordEncoder passwordEncoder;
-
-    @Transactional
-    public void joinProcess(JoinDto joinDto) {
-        String email = joinDto.getEmail();
-
-        if (authRepository.existsByEmail(email)) {
-            throw new BusinessException(BaseCode.EMAIL_DUPLICATE);
-        }
-
-        Member member = Member.builder()
-                .email(email)
-                .password(passwordEncoder.encode(joinDto.getPassword()))
-                .name(joinDto.getName())
-                .phone(joinDto.getPhone())
-                .role(USER)
-                .ratingScore(1000)
-                .activated(NORMAL)
-                .build();
-
-        authRepository.save(member);
-    }
+    void joinProcess(JoinRequest joinRequest);
 }

--- a/src/main/java/com/ureca/snac/auth/service/JoinServiceImpl.java
+++ b/src/main/java/com/ureca/snac/auth/service/JoinServiceImpl.java
@@ -1,0 +1,44 @@
+package com.ureca.snac.auth.service;
+
+import com.ureca.snac.auth.dto.request.JoinRequest;
+import com.ureca.snac.auth.exception.BusinessException;
+import com.ureca.snac.auth.repository.AuthRepository;
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ureca.snac.member.Activated.*;
+import static com.ureca.snac.member.Role.*;
+
+@Service
+@RequiredArgsConstructor
+public class JoinServiceImpl implements JoinService{
+
+    private final AuthRepository authRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void joinProcess(JoinRequest joinRequest) {
+        String email = joinRequest.getEmail();
+
+        if (authRepository.existsByEmail(email)) {
+            throw new BusinessException(BaseCode.EMAIL_DUPLICATE);
+        }
+
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(joinRequest.getPassword()))
+                .name(joinRequest.getName())
+                .phone(joinRequest.getPhone())
+                .role(USER)
+                .ratingScore(1000)
+                .activated(NORMAL)
+                .build();
+
+        authRepository.save(member);
+    }
+}

--- a/src/main/java/com/ureca/snac/auth/service/SnsService.java
+++ b/src/main/java/com/ureca/snac/auth/service/SnsService.java
@@ -1,0 +1,55 @@
+package com.ureca.snac.auth.service;
+
+import com.ureca.snac.auth.exception.SmsSendFailedException;
+import com.ureca.snac.common.BaseCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SnsService {
+
+    private final SnsClient snsClient;
+
+    public String sendVerificationCode(String phoneNumber) {
+        String verificationCode = generateRandomCode();
+        String message = String.format("[SNAC] 인증번호[%s]를 입력해주세요.", verificationCode);
+
+        String formatPhoneNumber = formatToE164(phoneNumber);
+
+        PublishRequest request = PublishRequest.builder()
+                .message(message)
+                .phoneNumber(formatPhoneNumber)
+                .build();
+
+        try {
+            PublishResponse response = snsClient.publish(request);
+            log.info("Sent message {} to {} with messageId {}", message, phoneNumber, response.messageId());
+        } catch (Exception e) {
+            log.error("Error sending SMS to {}: {}", formatPhoneNumber, e.getMessage(), e);
+            throw new SmsSendFailedException(BaseCode.SMS_SEND_FAILED);
+        }
+        return verificationCode;
+    }
+
+    // 6자리 숫자 랜덤으로.
+    private String generateRandomCode() {
+        Random random = new Random();
+        int number = random.nextInt(900000) + 100000;
+        return String.valueOf(number);
+    }
+
+    private String formatToE164(String phoneNumber) {
+        if (phoneNumber.startsWith("0")) {
+            return "+82" + phoneNumber.substring(1);
+        }
+        return phoneNumber;
+    }
+}

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -8,10 +8,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BaseCode {
 
-    // join
+    // 회원가입 - 성공
     STATUS_OK("STATUS_OK_200", HttpStatus.OK, "서버가 정상적으로 동작 중입니다."),
     USER_SIGNUP_SUCCESS("USER_SIGNUP_SUCCESS_201", HttpStatus.CREATED, "정상적으로 회원가입 되었습니다."),
+
+    // 회원가입 - 예외
     EMAIL_DUPLICATE("EMAIL_DUPLICATE_409", HttpStatus.CONFLICT, "이미 사용중인 이메일입니다."),
+
+    // 인증코드 발송- 성공
+    SMS_VERIFICATION_SENT("SMS_VERIFICATION_SENT_200", HttpStatus.OK, "인증번호가 발송되었습니다."),
+    // 인증코드 발송- 예외
+    SMS_SEND_FAILED("SMS_SEND_FAILED_500", HttpStatus.INTERNAL_SERVER_ERROR, "SMS 전송에 실패했습니다."),
+
 
     // 은행 - 성공
     BANK_CREATE_SUCCESS("BANK_CREATE_SUCCESS_201", HttpStatus.CREATED, "은행이 성공적으로 생성되었습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,13 @@
 spring:
   application:
     name: snac-server
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_SNS_ACCESS_KEY}
+        secret-key: ${AWS_SNS_SECRET_KEY}
+      region:
+        static: ${REGION}
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 📝 변경 사항

feat: AWS SNS 클라이언트 구성을 위한 SnsConfig 구현

feat: SMS 전송 및 유효성 검증을 담당하는 SnsService 생성

feat: SMS 관련 성공/실패 상황을 위한 예외 및 BaseCode 정의

feat: 휴대폰 인증을 위한 PhoneRequest, VerificationCodeResponse DTO 추가

feat: application.yml에 AWS SNS 설정값(플레이스홀더) 추가

refactor: 회원가입 관련 서비스 리팩토링: 비즈니스 로직 분리하여 JoinServiceImpl로 이전

fix: 리팩토링된 가입 플로우에 맞게 JoinController 수정

fix: AuthExceptionHandler를 개선하여 ResponseEntity로 올바른 HTTP 응답 반환

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 