### PR TITLE
[feat] 구매 및 판매글 가격 필터링 보완

### DIFF
--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.board.controller;
 
+import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.board.controller.request.CreateCardRequest;
 import com.ureca.snac.board.controller.request.UpdateCardRequest;
 import com.ureca.snac.board.entity.constants.CardCategory;
@@ -11,6 +12,7 @@ import com.ureca.snac.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,8 +30,9 @@ public class CardController implements CardControllerSwagger{
 
     @Override
     @PostMapping
-    public ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request) {
-        cardService.createCard(1L, request);
+    public ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request,
+                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        cardService.createCard(customUserDetails.getUsername(), request);
 
         return ResponseEntity.status(CARD_CREATE_SUCCESS.getStatus())
                 .body(ApiResponse.ok(CARD_CREATE_SUCCESS));
@@ -38,8 +41,9 @@ public class CardController implements CardControllerSwagger{
     @Override
     @PutMapping("/{cardId}")
     public ResponseEntity<ApiResponse<?>> editCard(@PathVariable("cardId") Long cardId,
-                                                   @Validated @RequestBody UpdateCardRequest updateCardRequest) {
-        cardService.updateCard(1L, cardId, updateCardRequest);
+                                                   @Validated @RequestBody UpdateCardRequest updateCardRequest,
+                                                   @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        cardService.updateCard(customUserDetails.getUsername(), cardId, updateCardRequest);
 
         return ResponseEntity.status(CARD_UPDATE_SUCCESS.getStatus())
                 .body(ApiResponse.ok(CARD_UPDATE_SUCCESS));
@@ -61,8 +65,9 @@ public class CardController implements CardControllerSwagger{
 
     @Override
     @DeleteMapping("/{cardId}")
-    public ResponseEntity<ApiResponse<?>> removeCard(@PathVariable("cardId") Long cardId) {
-        cardService.deleteCard(1L, cardId);
+    public ResponseEntity<ApiResponse<?>> removeCard(@PathVariable("cardId") Long cardId,
+                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        cardService.deleteCard(customUserDetails.getUsername(), cardId);
 
         return ResponseEntity.ok(ApiResponse.ok(CARD_DELETE_SUCCESS));
     }

--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -22,10 +22,11 @@ import static com.ureca.snac.common.BaseCode.*;
 @RestController
 @RequestMapping("/api/cards")
 @RequiredArgsConstructor
-public class CardController {
+public class CardController implements CardControllerSwagger{
 
     private final CardService cardService;
 
+    @Override
     @PostMapping
     public ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request) {
         cardService.createCard(1L, request);
@@ -34,6 +35,7 @@ public class CardController {
                 .body(ApiResponse.ok(CARD_CREATE_SUCCESS));
     }
 
+    @Override
     @PutMapping("/{cardId}")
     public ResponseEntity<ApiResponse<?>> editCard(@PathVariable("cardId") Long cardId,
                                                    @Validated @RequestBody UpdateCardRequest updateCardRequest) {
@@ -43,6 +45,7 @@ public class CardController {
                 .body(ApiResponse.ok(CARD_UPDATE_SUCCESS));
     }
 
+    @Override
     @GetMapping("/scroll")
     public ResponseEntity<ApiResponse<ScrollCardResponse>> scrollCards(@RequestParam CardCategory cardCategory,
                                                                        @RequestParam(required = false) Carrier carrier,
@@ -56,6 +59,7 @@ public class CardController {
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, response));
     }
 
+    @Override
     @DeleteMapping("/{cardId}")
     public ResponseEntity<ApiResponse<?>> removeCard(@PathVariable("cardId") Long cardId) {
         cardService.deleteCard(1L, cardId);

--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.ureca.snac.common.BaseCode.*;
 
@@ -44,13 +45,13 @@ public class CardController {
 
     @GetMapping("/scroll")
     public ResponseEntity<ApiResponse<ScrollCardResponse>> scrollCards(@RequestParam CardCategory cardCategory,
-                                                          @RequestParam(required = false) Carrier carrier,
-                                                          @RequestParam(defaultValue = "ALL") PriceRange priceRange,
-                                                          @RequestParam(defaultValue = "9") int size,
-                                                          @RequestParam(required = false) Long lastCardId,
-                                                          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt) {
+                                                                       @RequestParam(required = false) Carrier carrier,
+                                                                       @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
+                                                                       @RequestParam(defaultValue = "54") int size,
+                                                                       @RequestParam(required = false) Long lastCardId,
+                                                                       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt) {
 
-        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRange, size, lastCardId, lastUpdatedAt);
+        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRanges, size, lastCardId, lastUpdatedAt);
 
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, response));
     }

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -1,0 +1,84 @@
+package com.ureca.snac.board.controller;
+
+
+import com.ureca.snac.board.controller.request.CreateCardRequest;
+import com.ureca.snac.board.controller.request.UpdateCardRequest;
+import com.ureca.snac.board.entity.constants.CardCategory;
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.board.entity.constants.PriceRange;
+import com.ureca.snac.board.service.response.ScrollCardResponse;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.swagger.annotation.error.ErrorCode400;
+import com.ureca.snac.swagger.annotation.error.ErrorCode401;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiCreatedResponse;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Tag(name = "판매글/구매글 관리", description = "판매글(SELL), 구매글(BUY) 등록, 조회, 삭제, 수정 기능 제공")
+@SecurityRequirement(name = "Authorization")
+public interface CardControllerSwagger {
+
+    @Operation(
+            summary = "판매글 또는 구매글 등록",
+            description = "새로운 판매글(SELL) 또는 구매글(BUY)을 등록합니다. 입력값이 유효해야 합니다."
+    )
+    @ApiCreatedResponse(description = "등록 성공")
+    @ErrorCode400(description = "등록 실패 - 입력값이 잘못되었습니다.")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @PostMapping
+    ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request);
+
+    @Operation(
+            summary = "판매글 또는 구매글 수정",
+            description = "기존에 등록된 판매글(SELL) 또는 구매글(BUY)의 정보를 수정합니다."
+    )
+    @ApiSuccessResponse(description = "수정 성공")
+    @ErrorCode400(description = "수정 실패 - 입력값이 잘못되었습니다.")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @ErrorCode404(description = "존재하지 않는 글 ID")
+    @PutMapping("/{cardId}")
+    ResponseEntity<ApiResponse<?>> editCard(@PathVariable("cardId") Long cardId, @Validated @RequestBody UpdateCardRequest updateCardRequest);
+
+    @Operation(
+            summary = "판매글 또는 구매글 목록 조회 (스크롤)",
+            description = """
+        조건에 맞는 판매글(SELL) 또는 구매글(BUY)을 스크롤 방식으로 조회합니다.
+        - `cardCategory`, `priceRanges`는 필수이며, SELL 또는 BUY 중 하나  
+        - `carrier`는 선택적 필터  
+        - 커서 페이징 방식 사용  
+        - 초기 조회 시에는 `lastCardId`, `lastUpdatedAt` 없이 호출 가능  
+        - 이후 추가 조회(더보기) 시에는 두 값 모두 전달해야 합니다.
+        """
+    )
+    @ApiSuccessResponse(description = "목록 조회 성공")
+    @ErrorCode400(description = "조회 실패 - 잘못된 요청 파라미터")
+    @ErrorCode404(description = "조회 실패 - 존재하지 않는 판매글 또는 구매글")
+    @GetMapping("/scroll")
+    ResponseEntity<ApiResponse<ScrollCardResponse>> scrollCards(@RequestParam CardCategory cardCategory,
+                                                                       @RequestParam(required = false) Carrier carrier,
+                                                                       @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
+                                                                       @RequestParam(defaultValue = "54") int size,
+                                                                       @RequestParam(required = false) Long lastCardId,
+                                                                       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt);
+
+    @Operation(
+            summary = "판매글 또는 구매글 삭제",
+            description = "등록된 판매글(SELL) 또는 구매글(BUY)을 삭제합니다."
+    )
+    @ApiSuccessResponse(description = "삭제 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @ErrorCode404(description = "삭제 실패 - 존재하지 않는 글 ID")
+    @DeleteMapping("/{cardId}")
+    ResponseEntity<ApiResponse<?>> removeCard(@PathVariable("cardId") Long cardId);
+}

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.board.controller;
 
 
+import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.board.controller.request.CreateCardRequest;
 import com.ureca.snac.board.controller.request.UpdateCardRequest;
 import com.ureca.snac.board.entity.constants.CardCategory;
@@ -18,6 +19,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,7 +39,7 @@ public interface CardControllerSwagger {
     @ErrorCode400(description = "등록 실패 - 입력값이 잘못되었습니다.")
     @ErrorCode401(description = "인증되지 않은 사용자 접근")
     @PostMapping
-    ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request);
+    ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request, @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
     @Operation(
             summary = "판매글 또는 구매글 수정",
@@ -48,7 +50,7 @@ public interface CardControllerSwagger {
     @ErrorCode401(description = "인증되지 않은 사용자 접근")
     @ErrorCode404(description = "존재하지 않는 글 ID")
     @PutMapping("/{cardId}")
-    ResponseEntity<ApiResponse<?>> editCard(@PathVariable("cardId") Long cardId, @Validated @RequestBody UpdateCardRequest updateCardRequest);
+    ResponseEntity<ApiResponse<?>> editCard(@PathVariable("cardId") Long cardId, @Validated @RequestBody UpdateCardRequest updateCardRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
     @Operation(
             summary = "판매글 또는 구매글 목록 조회 (스크롤)",
@@ -80,5 +82,5 @@ public interface CardControllerSwagger {
     @ErrorCode401(description = "인증되지 않은 사용자 접근")
     @ErrorCode404(description = "삭제 실패 - 존재하지 않는 글 ID")
     @DeleteMapping("/{cardId}")
-    ResponseEntity<ApiResponse<?>> removeCard(@PathVariable("cardId") Long cardId);
+    ResponseEntity<ApiResponse<?>> removeCard(@PathVariable("cardId") Long cardId, @AuthenticationPrincipal CustomUserDetails customUserDetails);
 }

--- a/src/main/java/com/ureca/snac/board/entity/Card.java
+++ b/src/main/java/com/ureca/snac/board/entity/Card.java
@@ -14,7 +14,10 @@ import lombok.NoArgsConstructor;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
-@Table(name = "card")
+@Table(name = "card",
+        indexes = {
+            @Index(name = "idx_card_updated_at_id", columnList = "updated_at, card_id")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Card extends BaseTimeEntity {

--- a/src/main/java/com/ureca/snac/board/repository/CardRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepository.java
@@ -1,10 +1,11 @@
 package com.ureca.snac.board.repository;
 
 import com.ureca.snac.board.entity.Card;
+import com.ureca.snac.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CardRepository extends JpaRepository<Card, Long>, CardRepositoryCustom {
-    Optional<Card> findByIdAndMemberId(Long cardId, Long memberId);
+    Optional<Card> findByIdAndMember(Long cardId, Member member);
 }

--- a/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CardRepositoryCustom {
-    List<Card> scroll(CardCategory cardCategory, Carrier carrier, PriceRange priceRange, int size, Long lastCardId, LocalDateTime localDateTime);
+    List<Card> scroll(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
 }

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -8,6 +8,7 @@ import com.ureca.snac.board.entity.constants.PriceRange;
 import com.ureca.snac.board.service.response.ScrollCardResponse;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface CardService {
 
@@ -15,7 +16,7 @@ public interface CardService {
 
     void updateCard(Long memberId, Long cardId, UpdateCardRequest updateCardRequest);
 
-    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, PriceRange priceRange, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
+    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
 
     void deleteCard(Long memberId, Long cardId);
 }

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -12,12 +12,43 @@ import java.util.List;
 
 public interface CardService {
 
+    /**
+     * 새로운 판매글 또는 구매글을 등록합니다.
+     *
+     * @param username 등록자 이메일
+     * @param request 등록할 카드 정보
+     * @return 생성된 카드의 식별자(ID)
+     */
     Long createCard(String username, CreateCardRequest request);
 
+    /**
+     * 기존 판매글 또는 구매글의 정보를 수정합니다.
+     *
+     * @param username 요청자 이메일
+     * @param cardId 수정할 카드 ID
+     * @param updateCardRequest 수정할 카드 정보
+     */
     void updateCard(String username, Long cardId, UpdateCardRequest updateCardRequest);
 
+    /**
+     * 조건에 맞는 판매글 또는 구매글 목록을 커서 기반으로 조회합니다.
+     *
+     * @param cardCategory 카드 분류 (SELL 또는 BUY)
+     * @param carrier 통신사 필터 (선택)
+     * @param priceRange 가격대 필터 (복수 선택 가능)
+     * @param size 조회할 데이터 개수
+     * @param lastCardId 커서: 마지막으로 조회된 카드 ID (선택)
+     * @param lastUpdatedAt 커서: 마지막으로 조회된 카드의 수정 시각 (선택)
+     * @return 스크롤 방식으로 응답하는 카드 목록과 다음 페이지 존재 여부
+     */
     ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
 
+    /**
+     * 카드(판매글/구매글)를 삭제합니다.
+     *
+     * @param username 요청자 이메일
+     * @param cardId 삭제할 카드 ID
+     */
     void deleteCard(String username, Long cardId);
 }
 

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -12,12 +12,12 @@ import java.util.List;
 
 public interface CardService {
 
-    Long createCard(Long memberId, CreateCardRequest request);
+    Long createCard(String username, CreateCardRequest request);
 
-    void updateCard(Long memberId, Long cardId, UpdateCardRequest updateCardRequest);
+    void updateCard(String username, Long cardId, UpdateCardRequest updateCardRequest);
 
     ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
 
-    void deleteCard(Long memberId, Long cardId);
+    void deleteCard(String username, Long cardId);
 }
 

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -63,8 +63,8 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
-    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, PriceRange priceRange, int size, Long lastCardId, LocalDateTime lastUpdatedAt) {
-        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRange, size + 1, lastCardId, lastUpdatedAt);
+    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, int size, Long lastCardId, LocalDateTime lastUpdatedAt) {
+        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRanges, size + 1, lastCardId, lastUpdatedAt);
 
         boolean hasNext = raw.size() > size;
 

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -33,8 +33,8 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public Long createCard(Long memberId, CreateCardRequest request) {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public Long createCard(String username, CreateCardRequest request) {
+        Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
 
         Card card = Card.builder().member(member)
                 .sellStatus(SellStatus.SELLING)
@@ -51,8 +51,9 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public void updateCard(Long memberId, Long cardId, UpdateCardRequest updateCardRequest) {
-        Card card = cardRepository.findByIdAndMemberId(cardId, memberId).orElseThrow(CardNotFoundException::new);
+    public void updateCard(String username, Long cardId, UpdateCardRequest updateCardRequest) {
+        Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
+        Card card = cardRepository.findByIdAndMember(cardId, member).orElseThrow(CardNotFoundException::new);
 
         card.update(
                 updateCardRequest.getCardCategory(),
@@ -80,8 +81,10 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
-    public void deleteCard(Long memberId, Long cardId) {
-        Card card = cardRepository.findByIdAndMemberId(cardId, memberId).orElseThrow(CardNotFoundException::new);
+    @Transactional
+    public void deleteCard(String username, Long cardId) {
+        Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
+        Card card = cardRepository.findByIdAndMember(cardId, member).orElseThrow(CardNotFoundException::new);
 
         cardRepository.delete(card);
     }


### PR DESCRIPTION
## 📝 변경 사항

1. 판매글/구매글 관련 API에 Swagger 추가
2. 커서 기반 페이징 API에 가격 필터링(`List<PriceRange>`) 기능 추가
3. PriceRange.ALL 포함 시 전체 가격대 조회되도록 로직 개선

## 🔍 변경 사항 세부 설명

- 기존 단일 가격 필터(PriceRange)에서 다중 가격 필터(List 형태)를 받을 수 있도록 API 개선
  -  여러 구간 중 하나라도 해당되면 포함 (OR 조건), ALL 포함 시 전체 가격 조회
- QueryDSL 조건문에서 priceRangeIn(...) 로 다중 조건 처리

- 스크롤 조회 API에서 커서 기반 페이징 동작을 명확히 문서화
  -  최초 요청 시 lastCardId, lastUpdatedAt 없이 가능
  - 이후 더보기 요청 시 두 값 모두 필요함

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 