### PR TITLE
Qi1 29 refresh redis 동기화

### DIFF
--- a/src/main/java/com/ureca/snac/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/snac/auth/config/SecurityConfig.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ureca.snac.auth.jwt.JWTFilter;
 import com.ureca.snac.auth.jwt.JWTUtil;
 import com.ureca.snac.auth.jwt.LoginFilter;
-import jakarta.servlet.http.HttpServletRequest;
+import com.ureca.snac.auth.repository.RefreshRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -41,7 +40,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, RefreshRepository refreshRepository) throws Exception {
         http.
                 cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration cfg = new CorsConfiguration();
@@ -70,7 +69,7 @@ public class SecurityConfig {
         http
                 .addFilterBefore(new JWTFilter(objectMapper, jwtUtil), LoginFilter.class);
         http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil,objectMapper), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil,objectMapper,refreshRepository), UsernamePasswordAuthenticationFilter.class);
 
 
         // jwt를 통한 인증/인가를 위해서 세션을 stateless 상태로 설정해야 됨

--- a/src/main/java/com/ureca/snac/auth/refresh/Refresh.java
+++ b/src/main/java/com/ureca/snac/auth/refresh/Refresh.java
@@ -1,0 +1,19 @@
+package com.ureca.snac.auth.refresh;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "refresh_token", timeToLive = 86400)
+public class Refresh {
+
+    @Id
+    private String email;
+
+    @Indexed
+    private String refresh;
+}

--- a/src/main/java/com/ureca/snac/auth/repository/RefreshRepository.java
+++ b/src/main/java/com/ureca/snac/auth/repository/RefreshRepository.java
@@ -1,0 +1,13 @@
+package com.ureca.snac.auth.repository;
+
+import com.ureca.snac.auth.refresh.Refresh;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends CrudRepository<Refresh, String> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}


### PR DESCRIPTION
## 📝 변경 사항

### 발급 시

- Refresh 토큰을 서버 저장소(DB 등)에 기록

### 갱신 시

- 클라이언트가 보낸 Refresh 토큰을 서버에서 조회·검증
- 기존 Refresh 토큰 삭제
- 새 Refresh 토큰 생성 후 저장 및 클라이언트에 전송

## 🔍 변경 사항 세부 설명

###기존 문제점

- 클라이언트에만 JWT를 보관하면, 탈취된 토큰은 만료 전까지 서버에서 막을 방법이 없음
- 로그아웃 시 프론트엔드에서 토큰을 삭제해도 이미 유출된 복제 토큰은 여전히 유효

해결 방안

- Refresh 토큰을 서버에 저장하여, 서버가 직접 검증&관리
- Refresh Rotate시 기존 토큰을 삭제하고 새 토큰만 유효하도록 처리



## 📷 스크린샷 (선택)
<img width="684" height="752" alt="image" src="https://github.com/user-attachments/assets/5dd07ad8-2837-4ca0-86c7-8b1a19c43486" />


<img width="1217" height="144" alt="image" src="https://github.com/user-attachments/assets/53f8eb07-6aac-445b-9626-6860a9901c8b" />


## TTL 설정
<img width="567" height="283" alt="image" src="https://github.com/user-attachments/assets/9b5119d1-4ba3-46a7-ae48-06cf3585545b" />

- 