### PR TITLE
[feat]  구매/판매 card를 통한 거래 신청(생성) 및 수락 기능 및 알림 생성 기능 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -92,7 +92,7 @@ public enum BaseCode {
     INSUFFICIENT_BALANCE("INSUFFICIENT_BALANCE_409", HttpStatus.CONFLICT, "잔액이 부족합니다."),
     DUPLICATE_TRADE_REQUEST("DUPLICATE_TRADE_REQUEST_409", HttpStatus.CONFLICT, "이미 요청된 거래가 있습니다."),
     TRADE_SELF_REQUEST("TRADE_SELF_REQUEST_400", HttpStatus.BAD_REQUEST, "자신의 글에는 거래를 요청할 수 없습니다."),
-    TRADE_PERMISSION_DENIED("TRADE_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "거래를 진행할 권한이 없습니다.");
+    TRADE_PERMISSION_DENIED("TRADE_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "거래를 진행할 권한이 없습니다."),
 
 
 

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -92,6 +92,10 @@ public enum BaseCode {
     INSUFFICIENT_BALANCE("INSUFFICIENT_BALANCE_409", HttpStatus.CONFLICT, "잔액이 부족합니다."),
     DUPLICATE_TRADE_REQUEST("DUPLICATE_TRADE_REQUEST_409", HttpStatus.CONFLICT, "이미 요청된 거래가 있습니다."),
     TRADE_SELF_REQUEST("TRADE_SELF_REQUEST_400", HttpStatus.BAD_REQUEST, "자신의 글에는 거래를 요청할 수 없습니다."),
+<<<<<<< HEAD
+=======
+    TRADE_PERMISSION_DENIED("TRADE_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "거래를 진행할 권한이 없습니다.");
+>>>>>>> 44eaba8 (feat: 거래 신청 및 수락 기능 추가)
 
 
     // 계좌 - 성공

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -92,10 +92,8 @@ public enum BaseCode {
     INSUFFICIENT_BALANCE("INSUFFICIENT_BALANCE_409", HttpStatus.CONFLICT, "잔액이 부족합니다."),
     DUPLICATE_TRADE_REQUEST("DUPLICATE_TRADE_REQUEST_409", HttpStatus.CONFLICT, "이미 요청된 거래가 있습니다."),
     TRADE_SELF_REQUEST("TRADE_SELF_REQUEST_400", HttpStatus.BAD_REQUEST, "자신의 글에는 거래를 요청할 수 없습니다."),
-<<<<<<< HEAD
-=======
     TRADE_PERMISSION_DENIED("TRADE_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "거래를 진행할 권한이 없습니다.");
->>>>>>> 44eaba8 (feat: 거래 신청 및 수락 기능 추가)
+
 
 
     // 계좌 - 성공

--- a/src/main/java/com/ureca/snac/notification/config/RabbitMqConfig.java
+++ b/src/main/java/com/ureca/snac/notification/config/RabbitMqConfig.java
@@ -1,0 +1,30 @@
+package com.ureca.snac.notification.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+// RabbitMQ 설정 클래스
+//
+public class RabbitMqConfig {
+    public static final String EXCHANGE = "notification.exchange"; // 메시지를 전달하는 교환기 이름, 메시지를 전달 받아 라우팅 규칙에 따라 큐로 전달
+    public static final String QUEUE = "notification.queue"; // 알림 메시지를 저장할 큐, 최종적으로 메시지가 저장되어 컨슈머가 읽어가는 버퍼
+    public static final String ROUTING_KEY = "notification.key"; // 라우팅에 사용될 라우팅 키, exchange 와  queue 를 연결하고 라우팅 키로 어떤 메세지가 해당 큐로 가야하는지 정의
+    // direct exchange 를 사용하므로 라우팅 키가 완전히 일치할 때만 메시지가 큐로 전달
+
+    @Bean
+    public Exchange exchange() {
+        // durable=true 로 설정하여 서버 재시작 시에도 Exchange 가 유지
+        return ExchangeBuilder.directExchange(EXCHANGE).durable(true).build();
+    }
+    @Bean
+    public Queue queue() {
+        // durable 큐 : 메시지가 큐에 남아있다가 컨슈머가 받을 때까지 보존
+        return QueueBuilder.durable(QUEUE).build();
+    }
+    @Bean
+    public Binding binding() {
+        return BindingBuilder.bind(queue()).to(exchange()).with(ROUTING_KEY).noargs();
+    }
+}

--- a/src/main/java/com/ureca/snac/notification/dto/NotificationMessage.java
+++ b/src/main/java/com/ureca/snac/notification/dto/NotificationMessage.java
@@ -1,0 +1,13 @@
+package com.ureca.snac.notification.dto;
+
+import com.ureca.snac.notification.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationMessage {
+    private Long memberToId;
+    private NotificationType type;
+    private Long tradeId;
+}

--- a/src/main/java/com/ureca/snac/notification/entity/Notification.java
+++ b/src/main/java/com/ureca/snac/notification/entity/Notification.java
@@ -1,8 +1,9 @@
-package com.ureca.snac.trade.entity;
+package com.ureca.snac.notification.entity;
 
 import com.ureca.snac.member.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,8 +19,12 @@ public class Notification {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "member_from_id")
+    private Member memberFrom;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_to_id")
+    private Member memberTo;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
@@ -27,4 +32,12 @@ public class Notification {
 
     @Column(name = "is_read", nullable = false)
     private boolean isRead;
+
+    @Builder
+    public Notification(Member memberFrom, Member memberTo, NotificationType type, boolean isRead) {
+        this.memberFrom = memberFrom;
+        this.memberTo = memberTo;
+        this.type = type;
+        this.isRead = isRead;
+    }
 }

--- a/src/main/java/com/ureca/snac/notification/entity/NotificationType.java
+++ b/src/main/java/com/ureca/snac/notification/entity/NotificationType.java
@@ -1,4 +1,4 @@
-package com.ureca.snac.trade.entity;
+package com.ureca.snac.notification.entity;
 
 public enum NotificationType {
     TRADE_REQUESTED,

--- a/src/main/java/com/ureca/snac/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ureca/snac/notification/repository/NotificationRepository.java
@@ -1,6 +1,6 @@
-package com.ureca.snac.trade.repository;
+package com.ureca.snac.notification.repository;
 
-import com.ureca.snac.trade.entity.Notification;
+import com.ureca.snac.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> { }

--- a/src/main/java/com/ureca/snac/notification/service/NotificationService.java
+++ b/src/main/java/com/ureca/snac/notification/service/NotificationService.java
@@ -1,0 +1,9 @@
+package com.ureca.snac.notification.service;
+
+import com.ureca.snac.member.Member;
+import com.ureca.snac.notification.entity.NotificationType;
+import com.ureca.snac.trade.entity.Trade;
+
+public interface NotificationService {
+    void notify(Member from, Member to, NotificationType type, Trade trade);
+}

--- a/src/main/java/com/ureca/snac/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/ureca/snac/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,50 @@
+package com.ureca.snac.notification.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.snac.member.Member;
+import com.ureca.snac.notification.config.RabbitMqConfig;
+import com.ureca.snac.notification.dto.NotificationMessage;
+import com.ureca.snac.notification.entity.Notification;
+import com.ureca.snac.notification.entity.NotificationType;
+import com.ureca.snac.notification.repository.NotificationRepository;
+import com.ureca.snac.trade.entity.Trade;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository repo;
+    private final AmqpTemplate amqp;
+    private final ObjectMapper mapper;
+
+    @Override
+    @Transactional
+    // 데이터 일관성을 위해 db 저장과 mq 하나의 트랜잭션으로
+    // but mq 발행 실패는 사용자 알림만 발생하고 서비스 전체 롤백은 필요 없으므로
+    // catch 블록에서 예외를 기록하고 롤백 x
+    public void notify(Member from, Member to, NotificationType type, Trade trade) {
+        // DB 저장
+        Notification n = Notification.builder()
+                .memberFrom(from)
+                .memberTo(to)
+                .type(type)
+                .isRead(false)
+                .build();
+        repo.save(n);
+
+        // RabbitMQ 로 알림 메시지 발행
+        NotificationMessage msg = new NotificationMessage(to.getId(), type, trade.getId());
+        try {
+            amqp.convertAndSend(RabbitMqConfig.EXCHANGE,
+                                RabbitMqConfig.ROUTING_KEY,
+                                mapper.writeValueAsString(msg));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();   // 서비스 흐름은 유지
+        }
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/controller/TradeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/TradeController.java
@@ -1,0 +1,44 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.auth.dto.CustomUserDetails;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.trade.dto.AcceptTradeRequest;
+import com.ureca.snac.trade.dto.TradeRequest;
+import com.ureca.snac.trade.service.TradeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/trades")
+@RequiredArgsConstructor
+public class TradeController {
+
+    private final TradeService tradeService;
+
+    // 거래 신청
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> requestTrade(@RequestBody TradeRequest dto,
+                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        String email = customUserDetails.getUsername();
+
+        return ResponseEntity.ok(
+                ApiResponse.of(BaseCode.STATUS_OK,
+                        tradeService.requestTradeByEmail(dto, email)));
+    }
+
+    // 수락
+    @PostMapping("/accept")
+    public ResponseEntity<ApiResponse<?>> accept(@RequestBody AcceptTradeRequest dto,
+                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        tradeService.acceptTradeByEmail(dto.getTradeId(),customUserDetails.getUsername());
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.STATUS_OK, null));
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/dto/AcceptTradeRequest.java
+++ b/src/main/java/com/ureca/snac/trade/dto/AcceptTradeRequest.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.trade.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AcceptTradeRequest {
+    private Long tradeId;
+}

--- a/src/main/java/com/ureca/snac/trade/dto/TradeRequest.java
+++ b/src/main/java/com/ureca/snac/trade/dto/TradeRequest.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.trade.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TradeRequest {
+    private Long cardId;
+}

--- a/src/main/java/com/ureca/snac/trade/dto/TradeResponse.java
+++ b/src/main/java/com/ureca/snac/trade/dto/TradeResponse.java
@@ -1,0 +1,12 @@
+package com.ureca.snac.trade.dto;
+
+import com.ureca.snac.trade.entity.TradeStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TradeResponse {
+    private Long tradeId;
+    private TradeStatus status;
+}

--- a/src/main/java/com/ureca/snac/trade/entity/Trade.java
+++ b/src/main/java/com/ureca/snac/trade/entity/Trade.java
@@ -52,7 +52,7 @@ public class Trade extends BaseTimeEntity {
 
     // 추가 (포인트/머니)
     @Enumerated(EnumType.STRING)
-    @Column(name = "payment_type", nullable = false)
+    @Column(name = "payment_type")
     private PaymentType paymentType;
 
     @Builder

--- a/src/main/java/com/ureca/snac/trade/exception/DuplicateTradeRequestException.java
+++ b/src/main/java/com/ureca/snac/trade/exception/DuplicateTradeRequestException.java
@@ -1,0 +1,6 @@
+package com.ureca.snac.trade.exception;
+import com.ureca.snac.common.exception.BusinessException;
+import static com.ureca.snac.common.BaseCode.DUPLICATE_TRADE_REQUEST;
+public class DuplicateTradeRequestException extends BusinessException {
+    public DuplicateTradeRequestException() { super(DUPLICATE_TRADE_REQUEST); }
+}

--- a/src/main/java/com/ureca/snac/trade/exception/TradeNotFoundException.java
+++ b/src/main/java/com/ureca/snac/trade/exception/TradeNotFoundException.java
@@ -1,0 +1,6 @@
+package com.ureca.snac.trade.exception;
+import com.ureca.snac.common.exception.BusinessException;
+import static com.ureca.snac.common.BaseCode.TRADE_NOT_FOUND;
+public class TradeNotFoundException extends BusinessException {
+    public TradeNotFoundException() { super(TRADE_NOT_FOUND); }
+}

--- a/src/main/java/com/ureca/snac/trade/exception/TradePermissionDeniedException.java
+++ b/src/main/java/com/ureca/snac/trade/exception/TradePermissionDeniedException.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.trade.exception;
+
+import com.ureca.snac.common.exception.BusinessException;
+
+import static com.ureca.snac.common.BaseCode.TRADE_PERMISSION_DENIED;
+
+public class TradePermissionDeniedException extends BusinessException {
+    public TradePermissionDeniedException() {
+        super(TRADE_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/exception/TradeSelfRequestException.java
+++ b/src/main/java/com/ureca/snac/trade/exception/TradeSelfRequestException.java
@@ -1,0 +1,6 @@
+package com.ureca.snac.trade.exception;
+import com.ureca.snac.common.exception.BusinessException;
+import static com.ureca.snac.common.BaseCode.TRADE_SELF_REQUEST;
+public class TradeSelfRequestException extends BusinessException {
+    public TradeSelfRequestException() { super(TRADE_SELF_REQUEST); }
+}

--- a/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
@@ -1,6 +1,13 @@
 package com.ureca.snac.trade.repository;
 
 import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TradeRepository extends JpaRepository<Trade, Long> {}
+import java.util.Optional;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+    Optional<Trade> findByCardIdAndBuyerIdAndStatusNot(Long cardId, Long buyerId, TradeStatus status);
+    Optional<Trade> findByIdAndStatus(Long id, TradeStatus status);   // 수락용
+
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeService.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeService.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.trade.service;
+
+import com.ureca.snac.trade.dto.TradeRequest;
+import com.ureca.snac.trade.dto.TradeResponse;
+
+public interface TradeService {
+    TradeResponse requestTrade(TradeRequest dto, Long requesterId);
+    TradeResponse requestTradeByEmail(TradeRequest dto, String email);
+    void acceptTrade(Long tradeId, Long accepterId);
+    void acceptTradeByEmail(Long tradeId, String email);
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeServiceImpl.java
@@ -1,0 +1,130 @@
+package com.ureca.snac.trade.service;
+
+import com.ureca.snac.board.exception.CardNotFoundException;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.trade.exception.TradeSelfRequestException;
+import com.ureca.snac.trade.exception.DuplicateTradeRequestException;
+import com.ureca.snac.trade.exception.TradeNotFoundException;
+import com.ureca.snac.trade.exception.TradePermissionDeniedException;
+
+import com.ureca.snac.board.entity.Card;
+import com.ureca.snac.board.entity.constants.CardCategory;
+import com.ureca.snac.board.repository.CardRepository;
+import com.ureca.snac.member.Member;
+import com.ureca.snac.member.MemberRepository;
+import com.ureca.snac.notification.entity.NotificationType;
+import com.ureca.snac.notification.service.NotificationService;
+import com.ureca.snac.trade.dto.TradeRequest;
+import com.ureca.snac.trade.dto.TradeResponse;
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeStatus;
+import com.ureca.snac.trade.repository.TradeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TradeServiceImpl implements TradeService {
+
+    private final TradeRepository tradeRepo;
+    private final CardRepository cardRepo;
+    private final MemberRepository memberRepo;        // proxy용
+    private final NotificationService notification;
+
+    // 거래 신청
+    // 판매/구매 카드를 기반으로 거래 요청 생성
+    // 진행 상황에 따라 RabbitMq 알림 발행
+    @Override
+    @Transactional
+    public TradeResponse requestTrade(TradeRequest dto, Long requesterId) {
+        // 거래 대상 카드 조회 및 유효성 검증
+        Card card = cardRepo.findById(dto.getCardId())
+                .orElseThrow(CardNotFoundException::new);
+
+        if (card.getMember().getId().equals(requesterId))
+            throw new TradeSelfRequestException(); // 본인 글에 거래요청 x
+
+        tradeRepo.findByCardIdAndBuyerIdAndStatusNot(
+                dto.getCardId(), requesterId, TradeStatus.CANCELED
+        ).ifPresent(t -> { throw new DuplicateTradeRequestException(); }); // 이미 동일 멤버가 요청한 거래가 있음
+
+        // 판매자 구매자 역할 결정 lazy proxy
+        Member seller = (card.getCardCategory() == CardCategory.SELL)
+                        ? card.getMember()
+                        : memberRepo.getReferenceById(requesterId);
+        Member buyer  = (card.getCardCategory() == CardCategory.BUY)
+                        ? card.getMember()
+                        : memberRepo.getReferenceById(requesterId);
+
+        Trade trade = Trade.builder()
+                .cardId(card.getId())
+                .seller(seller)
+                .buyer(buyer)
+                .carrier(card.getCarrier())
+                .priceGb(card.getPrice())          // 단위 가격
+                .dataAmount(card.getDataAmount())
+                .status(TradeStatus.REQUESTED)
+                .build();
+
+        tradeRepo.save(trade);
+
+        // 알림 (글 작성자가 'to', 신청자가 'from')
+        notification.notify(
+                memberRepo.getReferenceById(requesterId),
+                card.getMember(),
+                NotificationType.TRADE_REQUESTED,
+                trade);
+
+        return new TradeResponse(trade.getId(), trade.getStatus());
+    }
+
+    @Override
+    @Transactional
+    public TradeResponse requestTradeByEmail(TradeRequest dto, String email) {
+
+        // email → Member 조회 (id 포함)
+        Member requester = memberRepo.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+        Long requesterId = requester.getId();
+
+        // 기존 requestTrade 로직 재사용
+        return requestTrade(dto, requesterId);
+    }
+
+    // 수락
+    // 요청된 거래를 수락 상태로 변경하며 권한 검증.
+    // 진행 상황에 따라 RabbitMq 알림 발행
+    @Override @Transactional
+    public void acceptTrade(Long tradeId, Long accepterId) {
+        // REQUESTED 상태의 trade 조회
+        Trade trade = tradeRepo.findByIdAndStatus(tradeId, TradeStatus.REQUESTED)
+                .orElseThrow(TradeNotFoundException::new);
+
+        // 수락 권한 확인
+        boolean isSellerAccept = trade.getSeller().getId().equals(accepterId)
+                                 && !trade.getSeller().getId().equals(trade.getBuyer().getId());
+        boolean isBuyerAccept  = trade.getBuyer().getId().equals(accepterId)
+                                 && !trade.getBuyer().getId().equals(trade.getSeller().getId());
+
+        if (!isSellerAccept && !isBuyerAccept)
+            throw new TradePermissionDeniedException();
+
+        trade.changeStatus(TradeStatus.ACCEPTED);
+
+        // 신청자에게 알림 발송
+        Member from = memberRepo.getReferenceById(accepterId);
+        Member to   = isSellerAccept ? trade.getBuyer() : trade.getSeller();
+
+        notification.notify(from, to, NotificationType.TRADE_ACCEPTED, trade);
+    }
+
+    @Override @Transactional
+    public void acceptTradeByEmail(Long tradeId, String email) {
+
+        Member accepter = memberRepo.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+
+        acceptTrade(tradeId, accepter.getId());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,9 +29,9 @@ spring:
         format_sql: true
     open-in-view: false
 
-  rabbitmq:
-    host: localhost
-    port: 5672
+rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,10 @@ spring:
         format_sql: true
     open-in-view: false
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 📝 변경 사항

1. 구매/판매 card 를 통해 판매자 또는 구매자가 거래 신청을 할 수 있습니다.
2. 거래 신청 시 대상자는 알림을 받습니다. 동시에 거래가 생성됩니다. 
3. 요청 수락시 요청자는 알림을 받습니다.
4. 요청 수락시 거래 상태가 요청됨에서 수락됨으로 변경됩니다.
5. 알림 서비스를 위한 RabbitMQ 세팅했습니다.
6. 알림이 RabbitMQ 큐에 등록되며, 알림 테이블에 등록됩니다.

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 