### PR TITLE
[feat] 거래 데이터 전송 로직에 이미지 첨부 기능 연결

### DIFF
--- a/src/main/java/com/ureca/snac/trade/controller/AttachmentController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/AttachmentController.java
@@ -20,26 +20,6 @@ public class AttachmentController {
 
     private final AttachmentService attachmentService;
 
-    // 거래 스크린샷 업로드
-    // Content-Type: multipart/form-data
-    // image: <file>
-    @PostMapping(value = "/{tradeId}/attachment",
-                 consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<AttachmentResponseDto>> upload(
-            @PathVariable Long tradeId,
-            @RequestPart("image") MultipartFile image,
-            // SecurityContext 에서 id 꺼내기 (expression = "id" 는 사용자 정의 UserDetails 구현체 기준)
-            @AuthenticationPrincipal UserDetails userDetails) {
-
-        AttachmentRequestDto dto = new AttachmentRequestDto(image);
-        String email = userDetails.getUsername();
-
-        AttachmentResponseDto result =
-                attachmentService.upload(tradeId, email, dto);
-
-        return ResponseEntity.ok(ApiResponse.of(BaseCode.ATTACHMENT_UPLOAD_SUCCESS, result));
-    }
-
     // 거래 이미지 Presigned URL 발급
     @GetMapping("/{tradeId}/attachment-url")
     public ResponseEntity<ApiResponse<String>> getPresignedUrl(

--- a/src/main/java/com/ureca/snac/trade/service/AttachmentService.java
+++ b/src/main/java/com/ureca/snac/trade/service/AttachmentService.java
@@ -2,9 +2,10 @@ package com.ureca.snac.trade.service;
 
 import com.ureca.snac.trade.dto.AttachmentRequestDto;
 import com.ureca.snac.trade.dto.AttachmentResponseDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface AttachmentService {
 
-    AttachmentResponseDto upload(Long tradeId, String userEmail, AttachmentRequestDto dto); // 첨부 파일을 업로드
+    void upload(Long tradeId, String userEmail, MultipartFile image); // 첨부 파일을 업로드
     String generatePresignedUrl(Long tradeId, String userEmail); // 특정 첨부 파일에 대한 Presigned URL 을 생성하여 반환
 }

--- a/src/main/java/com/ureca/snac/trade/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/AttachmentServiceImpl.java
@@ -17,6 +17,7 @@ import com.ureca.snac.trade.repository.TradeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,7 @@ public class AttachmentServiceImpl implements AttachmentService {
     private final S3Uploader s3Uploader;
 
     @Override
-    public AttachmentResponseDto upload(Long tradeId, String userEmail, AttachmentRequestDto dto) {
+    public void upload(Long tradeId, String userEmail, MultipartFile image) {
 
         // 거래, 회원 검증 :
         Trade trade = tradeRepository.findById(tradeId)
@@ -49,7 +50,7 @@ public class AttachmentServiceImpl implements AttachmentService {
         }
 
         // S3 업로드, 객체 키 반환받음
-        String s3Key = s3Uploader.upload(dto.getImage(), S3Path.TRADE_ATTACHMENT);
+        String s3Key = s3Uploader.upload(image, S3Path.TRADE_ATTACHMENT);
 
         // 엔티티 저장
         Attachment attachment = Attachment.builder()
@@ -59,8 +60,6 @@ public class AttachmentServiceImpl implements AttachmentService {
                 .build();
 
         attachmentRepository.save(attachment);
-
-        return new AttachmentResponseDto(attachment.getId(), s3Key); // 여기선 객체키로 응답 (나중에 Presigned URL로 변경될 수 있음)
     }
 
     @Override

--- a/src/main/java/com/ureca/snac/trade/service/BasicTradeServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/BasicTradeServiceImpl.java
@@ -41,6 +41,7 @@ public class BasicTradeServiceImpl implements BasicTradeService {
     private final MemberRepository memberRepository;
     private final CardRepository cardRepository;
     private final WalletRepository walletRepository;
+    private final AttachmentService attachmentService;
 
     @Override
     @Transactional
@@ -94,6 +95,9 @@ public class BasicTradeServiceImpl implements BasicTradeService {
         } else if (trade.getSeller() != seller) { // 이미 지정된 판매자가 현재 요청자가 아닐 경우 권한 없음
             throw new TradeSendPermissionDeniedException();
         }
+
+        // 파일 업로드
+        attachmentService.upload(tradeId, username, picture);
 
         trade.changeStatus(DATA_SENT);
     }


### PR DESCRIPTION


## 📝 변경 사항

- sendTradeData 로직 내에서 스크린샷 파일 업로드는 AttachmentService로 분리
- AttachmentService는 권한 및 중복 검증, S3 업로드, 엔티티 저장을 전담
- sendTradeData는 비즈니스 상태 전이만 수행하도록 변경 (판매자 지정 및 DATA_SENT 전이)
- 기존 AttachmentController의 upload 엔드포인트는 사용하지 않음 (삭제)
- AttachmentService의 upload 반환형은 void로 변경
- 
## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)
<img width="452" height="639" alt="image" src="https://github.com/user-attachments/assets/e8f10b93-a6d2-449e-bbea-83dbb4385917" />
<img width="502" height="718" alt="image" src="https://github.com/user-attachments/assets/6249160d-833c-4aa8-8b50-69b42d94060f" />

- 