### PR TITLE
[feat] 거래 통계 조회 및 카드 상태 필터링·평점 순 정렬 기능 추가

### DIFF
--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -56,11 +56,13 @@ public class CardController implements CardControllerSwagger{
                                                                        @RequestParam(required = false) Carrier carrier,
                                                                        @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
                                                                        @RequestParam SellStatusFilter sellStatusFilter,
-                                                                       @RequestParam(defaultValue = "54") int size,
+                                                                       @RequestParam(defaultValue = "true") Boolean highRatingFirst,
+                                                                       @RequestParam(defaultValue = "54") Integer size,
                                                                        @RequestParam(required = false) Long lastCardId,
                                                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt) {
 
-        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRanges, sellStatusFilter, size, lastCardId, lastUpdatedAt);
+        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRanges,
+                sellStatusFilter, highRatingFirst, size, lastCardId, lastUpdatedAt);
 
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, response));
     }

--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -2,6 +2,7 @@ package com.ureca.snac.board.controller;
 
 import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.board.controller.request.CreateCardRequest;
+import com.ureca.snac.board.controller.request.SellStatusFilter;
 import com.ureca.snac.board.controller.request.UpdateCardRequest;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
@@ -54,11 +55,12 @@ public class CardController implements CardControllerSwagger{
     public ResponseEntity<ApiResponse<ScrollCardResponse>> scrollCards(@RequestParam CardCategory cardCategory,
                                                                        @RequestParam(required = false) Carrier carrier,
                                                                        @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
+                                                                       @RequestParam SellStatusFilter sellStatusFilter,
                                                                        @RequestParam(defaultValue = "54") int size,
                                                                        @RequestParam(required = false) Long lastCardId,
                                                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt) {
 
-        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRanges, size, lastCardId, lastUpdatedAt);
+        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRanges, sellStatusFilter, size, lastCardId, lastUpdatedAt);
 
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, response));
     }

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -59,6 +59,9 @@ public interface CardControllerSwagger {
                     조건에 맞는 판매글(SELL) 또는 구매글(BUY)을 스크롤 방식으로 조회합니다.
                     - `cardCategory`, `priceRanges`는 필수이며, SELL 또는 BUY 중 하나  
                     - `carrier`는 선택적 필터  
+                    - `highRatingFirst`는 평점 높은 회원 우선 조회 옵션입니다.  
+                      - `true`로 설정 시 평점 높은 순으로 정렬하여 반환  
+                      - `false`(기본)일 경우 최근 수정 순으로 정렬  
                     - 커서 페이징 방식 사용  
                     - 초기 조회 시에는 `lastCardId`, `lastUpdatedAt` 없이 호출 가능  
                     - 이후 추가 조회(더보기) 시에는 두 값 모두 전달해야 합니다.
@@ -72,7 +75,8 @@ public interface CardControllerSwagger {
                                                                 @RequestParam(required = false) Carrier carrier,
                                                                 @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
                                                                 @RequestParam SellStatusFilter sellStatusFilter,
-                                                                @RequestParam(defaultValue = "54") int size,
+                                                                @RequestParam(defaultValue = "true") Boolean highRatingFirst,
+                                                                @RequestParam(defaultValue = "54") Integer size,
                                                                 @RequestParam(required = false) Long lastCardId,
                                                                 @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt);
 

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -3,6 +3,7 @@ package com.ureca.snac.board.controller;
 
 import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.board.controller.request.CreateCardRequest;
+import com.ureca.snac.board.controller.request.SellStatusFilter;
 import com.ureca.snac.board.controller.request.UpdateCardRequest;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
@@ -55,24 +56,25 @@ public interface CardControllerSwagger {
     @Operation(
             summary = "판매글 또는 구매글 목록 조회 (스크롤)",
             description = """
-        조건에 맞는 판매글(SELL) 또는 구매글(BUY)을 스크롤 방식으로 조회합니다.
-        - `cardCategory`, `priceRanges`는 필수이며, SELL 또는 BUY 중 하나  
-        - `carrier`는 선택적 필터  
-        - 커서 페이징 방식 사용  
-        - 초기 조회 시에는 `lastCardId`, `lastUpdatedAt` 없이 호출 가능  
-        - 이후 추가 조회(더보기) 시에는 두 값 모두 전달해야 합니다.
-        """
+                    조건에 맞는 판매글(SELL) 또는 구매글(BUY)을 스크롤 방식으로 조회합니다.
+                    - `cardCategory`, `priceRanges`는 필수이며, SELL 또는 BUY 중 하나  
+                    - `carrier`는 선택적 필터  
+                    - 커서 페이징 방식 사용  
+                    - 초기 조회 시에는 `lastCardId`, `lastUpdatedAt` 없이 호출 가능  
+                    - 이후 추가 조회(더보기) 시에는 두 값 모두 전달해야 합니다.
+                    """
     )
     @ApiSuccessResponse(description = "목록 조회 성공")
     @ErrorCode400(description = "조회 실패 - 잘못된 요청 파라미터")
     @ErrorCode404(description = "조회 실패 - 존재하지 않는 판매글 또는 구매글")
     @GetMapping("/scroll")
     ResponseEntity<ApiResponse<ScrollCardResponse>> scrollCards(@RequestParam CardCategory cardCategory,
-                                                                       @RequestParam(required = false) Carrier carrier,
-                                                                       @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
-                                                                       @RequestParam(defaultValue = "54") int size,
-                                                                       @RequestParam(required = false) Long lastCardId,
-                                                                       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt);
+                                                                @RequestParam(required = false) Carrier carrier,
+                                                                @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
+                                                                @RequestParam SellStatusFilter sellStatusFilter,
+                                                                @RequestParam(defaultValue = "54") int size,
+                                                                @RequestParam(required = false) Long lastCardId,
+                                                                @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt);
 
     @Operation(
             summary = "판매글 또는 구매글 삭제",

--- a/src/main/java/com/ureca/snac/board/controller/request/SellStatusFilter.java
+++ b/src/main/java/com/ureca/snac/board/controller/request/SellStatusFilter.java
@@ -1,0 +1,7 @@
+package com.ureca.snac.board.controller.request;
+
+public enum SellStatusFilter {
+    ALL,        // PENDING 을 제외한 전부
+    SELLING,
+    SOLD_OUT
+}

--- a/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.board.repository;
 
+import com.ureca.snac.board.controller.request.SellStatusFilter;
 import com.ureca.snac.board.entity.Card;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
@@ -9,5 +10,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CardRepositoryCustom {
-    List<Card> scroll(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
+    List<Card> scroll(CardCategory cardCategory,
+                      Carrier carrier,
+                      List<PriceRange> priceRanges,
+                      SellStatusFilter sellStatusFilter,
+                      int size,
+                      Long lastCardId,
+                      LocalDateTime lastUpdatedAt);
 }

--- a/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
@@ -14,7 +14,8 @@ public interface CardRepositoryCustom {
                       Carrier carrier,
                       List<PriceRange> priceRanges,
                       SellStatusFilter sellStatusFilter,
-                      int size,
+                      Boolean highRatingFirst,
+                      Integer size,
                       Long lastCardId,
                       LocalDateTime lastUpdatedAt);
 }

--- a/src/main/java/com/ureca/snac/board/repository/CardRepositoryImpl.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepositoryImpl.java
@@ -3,11 +3,13 @@ package com.ureca.snac.board.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.snac.board.controller.request.SellStatusFilter;
 import com.ureca.snac.board.entity.Card;
 import com.ureca.snac.board.entity.QCard;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
 import com.ureca.snac.board.entity.constants.PriceRange;
+import com.ureca.snac.board.entity.constants.SellStatus;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
@@ -27,6 +29,7 @@ public class CardRepositoryImpl implements CardRepositoryCustom {
     public List<Card> scroll(CardCategory cardCategory,
                              Carrier carrier,
                              List<PriceRange> priceRanges,
+                             SellStatusFilter sellStatusFilter,
                              int size,
                              Long lastCardId, LocalDateTime lastUpdatedAt) {
 
@@ -37,11 +40,23 @@ public class CardRepositoryImpl implements CardRepositoryCustom {
                         c.cardCategory.eq(cardCategory),
                         ltCursor(lastCardId, lastUpdatedAt, c),
                         carrierEq(carrier, c),
-                        priceRangeIn(priceRanges, c)
+                        priceRangeIn(priceRanges, c),
+                        sellStatusCond(sellStatusFilter, c)
                 )
                 .orderBy(c.updatedAt.desc(), c.id.desc())
                 .limit(size)
                 .fetch();
+    }
+
+    private BooleanExpression sellStatusCond(SellStatusFilter sellStatusFilter, QCard c) {
+        if (sellStatusFilter == null || sellStatusFilter == SellStatusFilter.ALL) {
+            return c.sellStatus.ne(SellStatus.PENDING);
+        }
+        return switch (sellStatusFilter) {
+            case SELLING  -> c.sellStatus.eq(SellStatus.SELLING);
+            case SOLD_OUT -> c.sellStatus.eq(SellStatus.SOLD_OUT);
+            default -> null;
+        };
     }
 
     private BooleanExpression priceRangeIn(List<PriceRange> prList, QCard c) {

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.board.service;
 
 import com.ureca.snac.board.controller.request.CreateCardRequest;
+import com.ureca.snac.board.controller.request.SellStatusFilter;
 import com.ureca.snac.board.controller.request.UpdateCardRequest;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
@@ -41,7 +42,7 @@ public interface CardService {
      * @param lastUpdatedAt 커서: 마지막으로 조회된 카드의 수정 시각 (선택)
      * @return 스크롤 방식으로 응답하는 카드 목록과 다음 페이지 존재 여부
      */
-    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
+    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, SellStatusFilter sellStatusFilter, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
 
     /**
      * 카드(판매글/구매글)를 삭제합니다.

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -42,7 +42,8 @@ public interface CardService {
      * @param lastUpdatedAt 커서: 마지막으로 조회된 카드의 수정 시각 (선택)
      * @return 스크롤 방식으로 응답하는 카드 목록과 다음 페이지 존재 여부
      */
-    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, SellStatusFilter sellStatusFilter, int size, Long lastCardId, LocalDateTime lastUpdatedAt);
+    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, SellStatusFilter sellStatusFilter, Boolean highRatingFirst,
+                                   Integer size, Long lastCardId, LocalDateTime lastUpdatedAt);
 
     /**
      * 카드(판매글/구매글)를 삭제합니다.

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -71,8 +71,11 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
-    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, SellStatusFilter sellStatusFilter, int size, Long lastCardId, LocalDateTime lastUpdatedAt) {
-        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRanges, sellStatusFilter, size + 1, lastCardId, lastUpdatedAt);
+    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, SellStatusFilter sellStatusFilter, Boolean highRatingFirst,
+                                          Integer size, Long lastCardId, LocalDateTime lastUpdatedAt) {
+
+        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRanges, sellStatusFilter, highRatingFirst,
+                size + 1, lastCardId, lastUpdatedAt);
 
         boolean hasNext = raw.size() > size;
 

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.board.service;
 
 import com.ureca.snac.board.controller.request.CreateCardRequest;
+import com.ureca.snac.board.controller.request.SellStatusFilter;
 import com.ureca.snac.board.controller.request.UpdateCardRequest;
 import com.ureca.snac.board.entity.Card;
 import com.ureca.snac.board.entity.constants.CardCategory;
@@ -70,8 +71,8 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
-    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, int size, Long lastCardId, LocalDateTime lastUpdatedAt) {
-        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRanges, size + 1, lastCardId, lastUpdatedAt);
+    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, SellStatusFilter sellStatusFilter, int size, Long lastCardId, LocalDateTime lastUpdatedAt) {
+        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRanges, sellStatusFilter, size + 1, lastCardId, lastUpdatedAt);
 
         boolean hasNext = raw.size() > size;
 

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -122,6 +122,7 @@ public enum BaseCode {
     TRADE_CONFIRM_SUCCESS("TRADE_CONFIRM_SUCCESS_200", HttpStatus.OK, "거래 확정에 성공하였습니다."),
     TRADE_SCROLL_SUCCESS("TRADE_SCROLL_SUCCESS_200", HttpStatus.OK, "거래 내역 조회에 성공하였습니다."),
     TRADE_PROGRESS_COUNT_SUCCESS("TRADE_PROGRESS_COUNT_SUCCESS_200", HttpStatus.OK, "진행 중인 거래 건수를 성공적으로 조회했습니다."),
+    TRADE_STATISTICS_READ_SUCCESS("STATISTICS_READ_SUCCESS_200", HttpStatus.OK, "거래 통계 데이터를 성공적으로 조회했습니다."),
 
     // 거래 - 실패
     TRADE_NOT_FOUND("TRADE_NOT_FOUND_404", HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
@@ -136,6 +137,8 @@ public enum BaseCode {
     TRADE_INVALID_STATUS("TRADE_INVALID_STATUS_400", HttpStatus.BAD_REQUEST, "잘못된 거래 상태입니다."),
     TRADE_SEND_PERMISSION_DENIED("TRADE_SEND_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "판매자만 거래 데이터를 전송할 수 있습니다."),
     TRADE_CONFIRM_PERMISSION_DENIED("TRADE_CONFIRM_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "구매자만 거래를 완료할 수 있습니다."),
+    TRADE_STATISTICS_NOT_FOUND("STATISTICS_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 통신사의 통계 데이터가 존재하지 않습니다."),
+
 
     // 계좌 - 성공
     ACCOUNT_CREATE_SUCCESS("ACCOUNT_CREATE_SUCCESS_201", HttpStatus.CREATED, "계좌가 성공적으로 생성되었습니다."),

--- a/src/main/java/com/ureca/snac/config/SchedulingConfig.java
+++ b/src/main/java/com/ureca/snac/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.ureca.snac.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/ureca/snac/trade/controller/TradeStatisticsController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/TradeStatisticsController.java
@@ -1,0 +1,29 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.trade.service.TradeStatisticsService;
+import com.ureca.snac.trade.service.response.TradeStatisticsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.ureca.snac.common.BaseCode.TRADE_STATISTICS_READ_SUCCESS;
+
+@RestController
+@RequestMapping("/api/trade-statistics")
+@RequiredArgsConstructor
+public class TradeStatisticsController {
+
+    private final TradeStatisticsService tradeStatisticsService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<TradeStatisticsResponse>> getLatest(@RequestParam Carrier carrier) {
+
+        return ResponseEntity.ok(ApiResponse.of(TRADE_STATISTICS_READ_SUCCESS,
+                tradeStatisticsService.getLatestStatsByCarrier(carrier)));
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/controller/TradeStatisticsController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/TradeStatisticsController.java
@@ -16,7 +16,7 @@ import static com.ureca.snac.common.BaseCode.TRADE_STATISTICS_READ_SUCCESS;
 @RestController
 @RequestMapping("/api/trade-statistics")
 @RequiredArgsConstructor
-public class TradeStatisticsController {
+public class TradeStatisticsController implements TradeStatisticsControllerSwagger {
 
     private final TradeStatisticsService tradeStatisticsService;
 

--- a/src/main/java/com/ureca/snac/trade/controller/TradeStatisticsControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/TradeStatisticsControllerSwagger.java
@@ -1,0 +1,31 @@
+package com.ureca.snac.trade.controller;
+
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.swagger.annotation.error.ErrorCode400;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import com.ureca.snac.trade.service.response.TradeStatisticsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "거래 통계", description = "캐리어별 최근 24시간 거래 통계 조회")
+public interface TradeStatisticsControllerSwagger {
+
+    @Operation(
+            summary = "캐리어별 최신 24시간 거래 통계 조회",
+            description = """
+            특정 캐리어(SK, KT, LG 등)의 가장 최근 저장된
+            24시간 거래 통계를 조회합니다.
+        """
+    )
+    @ApiSuccessResponse(description = "거래 통계 데이터 조회 성공")
+    @ErrorCode400(description = "조회 실패 - 잘못된 요청 파라미터")
+    @ErrorCode404(description = "조회 실패 - 해당 캐리어 통계 데이터 없음")
+    @GetMapping
+    ResponseEntity<ApiResponse<TradeStatisticsResponse>> getLatest(@RequestParam Carrier carrier);
+}

--- a/src/main/java/com/ureca/snac/trade/entity/TradeStatistics.java
+++ b/src/main/java/com/ureca/snac/trade/entity/TradeStatistics.java
@@ -1,0 +1,33 @@
+package com.ureca.snac.trade.entity;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "trade_statistics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TradeStatistics extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "trade_statistics_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Carrier carrier;
+
+    private Double avgTotalPrice;
+
+    @Builder
+    private TradeStatistics(Carrier carrier, Double avgTotalPrice) {
+        this.carrier = carrier;
+        this.avgTotalPrice = avgTotalPrice;
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/exception/TradeStatisticsNotFoundException.java
+++ b/src/main/java/com/ureca/snac/trade/exception/TradeStatisticsNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.trade.exception;
+
+import com.ureca.snac.common.exception.BusinessException;
+
+import static com.ureca.snac.common.BaseCode.TRADE_STATISTICS_NOT_FOUND;
+
+public class TradeStatisticsNotFoundException extends BusinessException {
+    public TradeStatisticsNotFoundException() {
+        super(TRADE_STATISTICS_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.repository;
 
+import com.ureca.snac.board.entity.constants.Carrier;
 import com.ureca.snac.member.Member;
 import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.entity.TradeStatus;
@@ -8,7 +9,9 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface TradeRepository extends JpaRepository<Trade, Long>, CustomTradeRepository {
@@ -21,4 +24,6 @@ public interface TradeRepository extends JpaRepository<Trade, Long>, CustomTrade
 
     long countBySellerAndStatusIn(Member seller, Collection<TradeStatus> statuses);
     long countByBuyerAndStatusIn(Member buyer, Collection<TradeStatus> statuses);
+
+    List<Trade> findAllByStatusAndCarrierAndCreatedAtBetween(TradeStatus status, Carrier carrier, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/ureca/snac/trade/repository/TradeStatisticsRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeStatisticsRepository.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.trade.repository;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.trade.entity.TradeStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TradeStatisticsRepository extends JpaRepository<TradeStatistics, Long> {
+    Optional<TradeStatistics> findFirstByCarrierOrderByIdDesc(Carrier carrier);
+}

--- a/src/main/java/com/ureca/snac/trade/scheduler/TradeStatisticsScheduler.java
+++ b/src/main/java/com/ureca/snac/trade/scheduler/TradeStatisticsScheduler.java
@@ -1,0 +1,55 @@
+package com.ureca.snac.trade.scheduler;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeStatistics;
+import com.ureca.snac.trade.entity.TradeStatus;
+import com.ureca.snac.trade.repository.TradeRepository;
+import com.ureca.snac.trade.repository.TradeStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TradeStatisticsScheduler {
+
+    private final TradeRepository tradeRepository;
+    private final TradeStatisticsRepository tradeStatisticsRepository;
+
+//    @Scheduled(cron = "0 0 * * * *")
+    public void recordHourlyAverageByCarrier() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime since = now.minusHours(24);
+
+        for (Carrier carrier : Carrier.values()) {
+            List<Trade> trades = tradeRepository
+                    .findAllByStatusAndCarrierAndCreatedAtBetween(
+                            TradeStatus.COMPLETED,
+                            carrier,
+                            since,
+                            now
+                    );
+
+            int totalDataAmount = 0;
+            int totalCost       = 0;
+
+            for (Trade trade : trades) {
+                totalCost       += trade.getPriceGb();
+                totalDataAmount += trade.getDataAmount();
+            }
+
+            double avgPricePerGb = totalDataAmount == 0 ? 0.0 : (double) totalCost / totalDataAmount;
+
+            TradeStatistics stat = TradeStatistics.builder()
+                    .carrier(carrier)
+                    .avgTotalPrice(avgPricePerGb)
+                    .build();
+
+            tradeStatisticsRepository.save(stat);
+
+        }
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeStatisticsService.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeStatisticsService.java
@@ -1,0 +1,8 @@
+package com.ureca.snac.trade.service;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.trade.service.response.TradeStatisticsResponse;
+
+public interface TradeStatisticsService {
+    TradeStatisticsResponse getLatestStatsByCarrier(Carrier carrier);
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeStatisticsServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeStatisticsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.ureca.snac.trade.service;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.trade.entity.TradeStatistics;
+import com.ureca.snac.trade.exception.TradeStatisticsNotFoundException;
+import com.ureca.snac.trade.repository.TradeStatisticsRepository;
+import com.ureca.snac.trade.service.response.TradeStatisticsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TradeStatisticsServiceImpl implements TradeStatisticsService {
+
+    private final TradeStatisticsRepository tradeStatisticsRepository;
+
+    @Override
+    public TradeStatisticsResponse getLatestStatsByCarrier(Carrier carrier) {
+        TradeStatistics stat = tradeStatisticsRepository
+                .findFirstByCarrierOrderByIdDesc(carrier)
+                .orElseThrow(TradeStatisticsNotFoundException::new);
+
+        return new TradeStatisticsResponse(stat.getCarrier(), stat.getAvgTotalPrice());
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeStatisticsResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeStatisticsResponse.java
@@ -1,0 +1,12 @@
+package com.ureca.snac.trade.service.response;
+
+import com.ureca.snac.board.entity.constants.Carrier;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TradeStatisticsResponse {
+    private Carrier carrier;
+    private Double avgPricePerGb;
+}


### PR DESCRIPTION
## 📝 변경 사항

1. 통신사별 거래 통계 조회 API 추가
2. 카드 거래 상태별 필터링 기능 추가
3. 등록자 평점 순 정렬(highRatingFirst) 기능 추가

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 