### PR TITLE
[feat] 카드 거래 상태별 거래 진행 차단 및 단계별 문자 알림 구현

### DIFF
--- a/src/main/java/com/ureca/snac/auth/service/SnsService.java
+++ b/src/main/java/com/ureca/snac/auth/service/SnsService.java
@@ -7,4 +7,6 @@ public interface SnsService {
     void verifyCode(String phoneNumber, String code);
 
     boolean isPhoneVerified(String phoneNumber);
+
+    void sendSms(String phoneNumber, String message);
 }

--- a/src/main/java/com/ureca/snac/auth/service/SnsServiceImpl.java
+++ b/src/main/java/com/ureca/snac/auth/service/SnsServiceImpl.java
@@ -2,7 +2,11 @@ package com.ureca.snac.auth.service;
 
 import com.ureca.snac.auth.exception.SmsSendFailedException;
 import com.ureca.snac.auth.exception.VerificationFailedException;
+import com.ureca.snac.board.entity.Card;
+import com.ureca.snac.board.entity.constants.SellStatus;
 import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -69,6 +73,24 @@ public class SnsServiceImpl implements SnsService {
 
         // 검증 완료 플래그
         redisTemplate.opsForValue().set(VERIFIED_FLAG_PREFIX + phoneNumber, "true", VERIFIED_FLAG_TTL);
+    }
+
+    @Override
+    public void sendSms(String phoneNumber, String message) {
+        String formatPhoneNumber = formatToE164(phoneNumber);
+
+        try {
+            PublishResponse response = snsClient.publish(PublishRequest.builder()
+                    .message(message)
+                    .phoneNumber(formatPhoneNumber)
+                    .build());
+
+            log.info("Sent message {} to {} with messageId {}", message, phoneNumber, response.messageId());
+
+        } catch (Exception e) {
+            log.error("Error sending SMS to {}: {}", formatPhoneNumber, e.getMessage(), e);
+            throw new SmsSendFailedException();
+        }
     }
 
     @Override

--- a/src/main/java/com/ureca/snac/common/advice/GlobalAdvice.java
+++ b/src/main/java/com/ureca/snac/common/advice/GlobalAdvice.java
@@ -23,7 +23,7 @@ public class GlobalAdvice {
         if (e instanceof ExternalApiException) {
             log.error("외부 API 호출 예외 발생 : {}", e.getMessage(), e);
         } else {
-            log.warn("내부 비즈니스 예외 발생 : {}", e.getMessage());
+            log.warn("내부 비즈니스 예외 발생 : ", e);
         }
 
         return ResponseEntity

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.trade.controller;
 
 import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.BasicTradeService;
@@ -52,6 +53,14 @@ public class BasicTradeController implements BasicTradeControllerSwagger {
         basicTradeService.createBuyTrade(createTradeRequest, userDetails.getUsername());
 
         return ResponseEntity.ok(ApiResponse.ok(TRADE_CREATE_SUCCESS));
+    }
+
+    @PostMapping("/buy/accept")
+    public ResponseEntity<ApiResponse<?>> acceptBuyRequest(@RequestBody ClaimBuyRequest claimBuyRequest,
+                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        basicTradeService.acceptBuyRequest(claimBuyRequest, userDetails.getUsername());
+        return ResponseEntity
+                .ok(ApiResponse.ok(TRADE_ACCEPT_SUCCESS));
     }
 
     @PatchMapping("/{tradeId}/cancel")

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeControllerSwagger.java
@@ -4,6 +4,7 @@ import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.swagger.annotation.error.*;
 import com.ureca.snac.swagger.annotation.response.ApiCreatedResponse;
 import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
@@ -93,4 +94,13 @@ public interface BasicTradeControllerSwagger {
                                                                   @RequestParam(defaultValue = "10") int size,
                                                                   @RequestParam(required = false, name = "cursorId") Long cursorId,
                                                                   @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "구매글 거래 수락", description = "판매자가 구매글에 대해 거래를 수락하고, 카드 상태를 TRADING으로 변경합니다.")
+    @ApiSuccessResponse(description = "거래 수락 성공")
+    @ErrorCode400(description = "잘못된 거래 상태로 인해 수락할 수 없습니다.")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @ErrorCode404(description = "거래를 찾을 수 없습니다.")
+    @PostMapping("/buy/accept")
+    ResponseEntity<ApiResponse<?>> acceptBuyRequest(@RequestBody ClaimBuyRequest claimBuyRequest,
+                                                    @AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/com/ureca/snac/trade/controller/request/ClaimBuyRequest.java
+++ b/src/main/java/com/ureca/snac/trade/controller/request/ClaimBuyRequest.java
@@ -1,0 +1,8 @@
+package com.ureca.snac.trade.controller.request;
+
+import lombok.Getter;
+
+@Getter
+public class ClaimBuyRequest {
+    private Long cardId;
+}

--- a/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
@@ -26,4 +26,7 @@ public interface TradeRepository extends JpaRepository<Trade, Long>, CustomTrade
     long countByBuyerAndStatusIn(Member buyer, Collection<TradeStatus> statuses);
 
     List<Trade> findAllByStatusAndCarrierAndCreatedAtBetween(TradeStatus status, Carrier carrier, LocalDateTime start, LocalDateTime end);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Trade> findLockedByCardId(Long cardId);
 }

--- a/src/main/java/com/ureca/snac/trade/service/BasicTradeService.java
+++ b/src/main/java/com/ureca/snac/trade/service/BasicTradeService.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.service;
 
+import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
@@ -76,4 +77,12 @@ public interface BasicTradeService {
      * @return 진행 중 거래 건수
      */
     ProgressTradeCountResponse countBuyingProgress(String username);
+
+    /**
+     * 구매글에 판매자가 거래 신청을 하고, 카드 상태를 TRADING으로 변경합니다.
+     *
+     * @param claimBuyRequest 구매글을 식별할 카드 ID를 포함한 DTO
+     * @param username        거래 신청을 수행하는 판매자 이메일
+     */
+    void acceptBuyRequest(ClaimBuyRequest claimBuyRequest, String username);
 }

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
@@ -27,13 +27,22 @@ public class TradeResponse {
     private LocalDateTime createdAt;
 
     public static TradeResponse from(Trade trade, TradeSide side) {
-        String maskedPhone = (side == TradeSide.SELL) ? null : trade.getPhone();
+        String phoneToShow = null;
+
+        // 구매자 측면에서는 언제나 본인 번호를 보여주고,
+        if (side == TradeSide.BUY) {
+            phoneToShow = trade.getPhone();
+        }
+        // 판매자 측면에서는 결제 확정 단계(PAYMENT_CONFIRMED)일 때만 보여줌
+        else if (side == TradeSide.SELL && trade.getStatus() == TradeStatus.PAYMENT_CONFIRMED) {
+            phoneToShow = trade.getPhone();
+        }
 
         return new TradeResponse(
                 trade.getId(),
                 trade.getPriceGb(),
                 trade.getDataAmount(),
-                maskedPhone,
+                phoneToShow,
                 trade.getCarrier(),
                 trade.getCancelReason(),
                 trade.getStatus(),


### PR DESCRIPTION
## 📝 변경 사항

1. 판매자 거래 요청(구매글 승인) 기능 추가
2. 거래 상태별 문자 알림 기능 구현

## 🔍 변경 사항 세부 설명

- POST /api/trades/buy/accept 엔드포인트 추가
  - 요청 파라미터로 cardId를 받아 해당 구매글에 판매자 승인 처리
- SMS 알림 기능
  - 거래 요청(구매글 승인), 데이터 전송, 거래 완료 등 주요 상태 알람

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 