### PR TITLE
[feat] 소켓 연결 종료 시 매칭 전 필터 및 등록 카드 자동 제거

### DIFF
--- a/src/main/java/com/ureca/snac/board/repository/CardRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepository.java
@@ -1,11 +1,14 @@
 package com.ureca.snac.board.repository;
 
 import com.ureca.snac.board.entity.Card;
+import com.ureca.snac.board.entity.constants.CardCategory;
+import com.ureca.snac.board.entity.constants.SellStatus;
 import com.ureca.snac.member.Member;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CardRepository extends JpaRepository<Card, Long>, CardRepositoryCustom {
@@ -16,4 +19,7 @@ public interface CardRepository extends JpaRepository<Card, Long>, CardRepositor
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Card> findLockedByIdAndMember(Long cardId, Member member);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Card> findLockedByMemberAndSellStatusAndCardCategory(Member member, SellStatus sellStatus, CardCategory cardCategory);
 }

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -8,6 +8,7 @@ import com.ureca.snac.board.dto.CardDto;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
 import com.ureca.snac.board.entity.constants.PriceRange;
+import com.ureca.snac.board.entity.constants.SellStatus;
 import com.ureca.snac.board.service.response.ScrollCardResponse;
 import com.ureca.snac.trade.controller.request.BuyerFilterRequest;
 
@@ -20,7 +21,7 @@ public interface CardService {
      * 새로운 판매글 또는 구매글을 등록합니다.
      *
      * @param username 등록자 이메일
-     * @param request 등록할 카드 정보
+     * @param request  등록할 카드 정보
      * @return 생성된 카드의 식별자(ID)
      */
     Long createCard(String username, CreateCardRequest request);
@@ -28,8 +29,8 @@ public interface CardService {
     /**
      * 기존 판매글 또는 구매글의 정보를 수정합니다.
      *
-     * @param username 요청자 이메일
-     * @param cardId 수정할 카드 ID
+     * @param username          요청자 이메일
+     * @param cardId            수정할 카드 ID
      * @param updateCardRequest 수정할 카드 정보
      */
     void updateCard(String username, Long cardId, UpdateCardRequest updateCardRequest);
@@ -37,11 +38,11 @@ public interface CardService {
     /**
      * 조건에 맞는 판매글 또는 구매글 목록을 커서 기반으로 조회합니다.
      *
-     * @param cardCategory 카드 분류 (SELL 또는 BUY)
-     * @param carrier 통신사 필터 (선택)
-     * @param priceRange 가격대 필터 (복수 선택 가능)
-     * @param size 조회할 데이터 개수
-     * @param lastCardId 커서: 마지막으로 조회된 카드 ID (선택)
+     * @param cardCategory  카드 분류 (SELL 또는 BUY)
+     * @param carrier       통신사 필터 (선택)
+     * @param priceRange    가격대 필터 (복수 선택 가능)
+     * @param size          조회할 데이터 개수
+     * @param lastCardId    커서: 마지막으로 조회된 카드 ID (선택)
      * @param lastUpdatedAt 커서: 마지막으로 조회된 카드의 수정 시각 (선택)
      * @return 스크롤 방식으로 응답하는 카드 목록과 다음 페이지 존재 여부
      */
@@ -52,7 +53,7 @@ public interface CardService {
      * 카드(판매글/구매글)를 삭제합니다.
      *
      * @param username 요청자 이메일
-     * @param cardId 삭제할 카드 ID
+     * @param cardId   삭제할 카드 ID
      */
     void deleteCard(String username, Long cardId);
 
@@ -61,5 +62,7 @@ public interface CardService {
     CardDto createRealtimeCard(String username, CreateRealTimeCardRequest request);
 
     List<CardDto> findRealtimeCardsByFilter(BuyerFilterRequest filter);
+
+    List<CardDto> findByMemberUsernameAndSellStatusAndCardCategory(String username, SellStatus sellStatus, CardCategory cardCategory);
 }
 

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -147,6 +147,16 @@ public class CardServiceImpl implements CardService {
         cardRepository.delete(card);
     }
 
+    @Transactional
+    public List<CardDto> findByMemberUsernameAndSellStatusAndCardCategory(String username, SellStatus sellStatus, CardCategory cardCategory) {
+        Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
+
+        return cardRepository.findLockedByMemberAndSellStatusAndCardCategory(member, sellStatus, cardCategory)
+                .stream()
+                .map(CardDto::from)
+                .toList();
+    }
+
     @Override
     @Transactional
     public void deleteCardByTrade(Long cardId) {

--- a/src/main/java/com/ureca/snac/common/RedisKeyConstants.java
+++ b/src/main/java/com/ureca/snac/common/RedisKeyConstants.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.common;
+
+public final class RedisKeyConstants {
+    private RedisKeyConstants() {}
+
+    // 현재 접속중인 사용자 셋 키
+    public static final String CONNECTED_USERS = "connected_users";
+
+    // 구매자 필터 저장용 키 prefix (“buyer_filter:{username}”)
+    public static final String BUYER_FILTER_PREFIX = "buyer_filter:";
+}

--- a/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
+++ b/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.config;
 
 import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -8,6 +9,7 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@EnableRabbit
 @Configuration
 public class RabbitMQConfig {
     /* ------------------- Topic : 실시간 서비스 전용 ------------------- */
@@ -58,7 +60,7 @@ public class RabbitMQConfig {
     }
 
 
-        /* ------------------- Direct : SMS 전용 ------------------- */
+    /* ------------------- Direct : SMS 전용 ------------------- */
     public static final String SMS_EXCHANGE     = "sms_exchange";
 
     // 거래·알림 문자

--- a/src/main/java/com/ureca/snac/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/ureca/snac/notification/service/NotificationServiceImpl.java
@@ -13,6 +13,8 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.ureca.snac.config.RabbitMQConfig.MATCHING_NOTIFICATION_EXCHANGE;
+
 @Service
 @RequiredArgsConstructor
 public class NotificationServiceImpl implements NotificationService {
@@ -24,7 +26,7 @@ public class NotificationServiceImpl implements NotificationService {
     private static final String EXCHANGE = RabbitMQConfig.NOTIFICATION_EXCHANGE;
     private static final String RK_FMT = "%s.%s";
 
-    private static final String MATCHING_EXCHANGE = RabbitMQConfig.MATCHING_NOTIFICATION_EXCHANGE;
+    private static final String MATCHING_EXCHANGE = MATCHING_NOTIFICATION_EXCHANGE;
 
     @Transactional
     public void notify(NotificationDTO notificationRequest) {
@@ -49,7 +51,7 @@ public class NotificationServiceImpl implements NotificationService {
     public void sendMatchingNotification(String username, CardDto cardDto) {
         System.out.println("매칭알림 MQ 발행: " + username + " " + cardDto);
         String routingKey = String.format("matching.notification.%s", username);
-        rabbitTemplate.convertAndSend(MATCHING_EXCHANGE, routingKey, cardDto);
+        rabbitTemplate.convertAndSend(MATCHING_NOTIFICATION_EXCHANGE, routingKey, cardDto);
     }
 
     private Member getMember(String email) {

--- a/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
@@ -4,17 +4,20 @@ import com.ureca.snac.board.controller.request.CreateRealTimeCardRequest;
 import com.ureca.snac.trade.controller.request.BuyerFilterRequest;
 import com.ureca.snac.trade.service.MatchingServiceFacade;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
 
-@RestController
+@Controller
 @RequiredArgsConstructor
 public class MatchingController {
 
     private final MatchingServiceFacade matchingServiceFacade;
+    private final StringRedisTemplate redisTemplate;
 
     @MessageMapping("/register-filter")
     public void registerBuyerFilter(@Payload BuyerFilterRequest filter, Principal principal) {
@@ -25,5 +28,11 @@ public class MatchingController {
     public void registerRealtimeCard(@Payload CreateRealTimeCardRequest request, Principal principal) {
         String username = principal.getName();
         matchingServiceFacade.createRealtimeCardAndNotifyBuyers(username, request);
+    }
+
+    @MessageMapping("/connected-users")
+    @SendToUser("/queue/connected-users")
+    public Long getConnectedUserCount(Principal principal) {
+        return matchingServiceFacade.getConnectedUserCount();
     }
 }

--- a/src/main/java/com/ureca/snac/trade/service/BuyFilterServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/BuyFilterServiceImpl.java
@@ -7,16 +7,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import static com.ureca.snac.common.RedisKeyConstants.BUYER_FILTER_PREFIX;
+
 @Service
 @RequiredArgsConstructor
 public class BuyFilterServiceImpl implements BuyFilterService {
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
-    private static final String PREFIX = "buyer_filter:";
 
     @Override
     public void saveBuyerFilter(String username, BuyerFilterRequest filter) {
-        String key = PREFIX + username;
+        String key = BUYER_FILTER_PREFIX + username;
 
         try {
             redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(filter));

--- a/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
+++ b/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
@@ -1,5 +1,9 @@
 package com.ureca.snac.trade.service;
 
+import com.ureca.snac.board.dto.CardDto;
+import com.ureca.snac.board.entity.constants.CardCategory;
+import com.ureca.snac.board.entity.constants.SellStatus;
+import com.ureca.snac.board.service.CardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -12,7 +16,9 @@ import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import java.security.Principal;
+import java.util.List;
 
+import static com.ureca.snac.common.RedisKeyConstants.BUYER_FILTER_PREFIX;
 import static com.ureca.snac.common.RedisKeyConstants.CONNECTED_USERS;
 
 @Slf4j
@@ -22,6 +28,7 @@ public class WebSocketTradeEventListener {
 
     private final StringRedisTemplate redisTemplate;
     private final SimpMessagingTemplate messaging;
+    private final CardService cardService;
 
     // 소켓 연결시 호출
     @EventListener
@@ -41,8 +48,29 @@ public class WebSocketTradeEventListener {
     public void handleSessionDisconnect(SessionDisconnectEvent event) {
         String username = extractUsername(event);
         if (username == null) return;
-        // Redis Set에서 제거
+
+        // 1. 접속자 목록에서 제거
         redisTemplate.opsForSet().remove(CONNECTED_USERS, username);
+
+        // 2. 필터링 조건 Redis 에서 제거 (구매자 역할일 수 있음)
+        String filterKey = BUYER_FILTER_PREFIX + username;
+        if (redisTemplate.hasKey(filterKey)) {
+            redisTemplate.delete(filterKey);
+            log.info("구매자 필터링 조건 삭제: {}", username);
+        }
+
+        // 3. DB에서 카드 조회 후 조건에 따라 제거 (판매자 역할일 수 있음)
+        List<CardDto> cards = cardService.findByMemberUsernameAndSellStatusAndCardCategory(
+                username,
+                SellStatus.SELLING,
+                CardCategory.REALTIME_SELL
+        );
+
+        for (CardDto card : cards) {
+            cardService.deleteCard(username, card.getId());
+            log.info("판매자 카드 삭제 완료: {}", username);
+        }
+
         broadcastUserCount();
     }
 

--- a/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
+++ b/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
@@ -1,0 +1,60 @@
+package com.ureca.snac.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.AbstractSubProtocolEvent;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+
+import static com.ureca.snac.common.RedisKeyConstants.CONNECTED_USERS;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketTradeEventListener {
+
+    private final StringRedisTemplate redisTemplate;
+    private final SimpMessagingTemplate messaging;
+
+    // 소켓 연결시 호출
+    @EventListener
+    public void handleSessionConnect(SessionConnectEvent event) {
+        String username = extractUsername(event);
+        if (username == null) return;
+
+        // Redis Set에 추가
+        redisTemplate.opsForSet().add(CONNECTED_USERS, username);
+
+        // 브로드 캐스트
+        broadcastUserCount();
+    }
+
+    // 소켓 해제시 호출
+    @EventListener
+    public void handleSessionDisconnect(SessionDisconnectEvent event) {
+        String username = extractUsername(event);
+        if (username == null) return;
+        // Redis Set에서 제거
+        redisTemplate.opsForSet().remove(CONNECTED_USERS, username);
+        broadcastUserCount();
+    }
+
+    private void broadcastUserCount() {
+        Long count = redisTemplate.opsForSet().size(CONNECTED_USERS);
+        messaging.convertAndSend("/topic/connected-users", count == null ? 0 : count);
+    }
+
+    // username 추출
+    private String extractUsername(AbstractSubProtocolEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Principal principal = accessor.getUser();
+        return (principal != null) ? principal.getName() : null;
+    }
+}


### PR DESCRIPTION
## 📝 변경 사항

1. WebSocket 연결·종료 이벤트 리스너에 실시간 접속자 수 집계 로직 추가
2. 세션 종료 시 Redis에 저장된 buyer_filter:{username} 키 삭제
3. 세션 종료 시 DB에 저장된 REALTIME_SELL & SELLING 카드 조회 후 일괄 삭제

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 