### PR TITLE
[feat] 실시간 매칭 - 데이터 전송, 거래 확정 구현

### DIFF
--- a/src/main/java/com/ureca/snac/board/repository/CardRepositoryImpl.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepositoryImpl.java
@@ -66,6 +66,7 @@ public class CardRepositoryImpl implements CardRepositoryCustom {
         QCard card = QCard.card;
 
         BooleanBuilder builder = new BooleanBuilder();
+        builder.and(card.sellStatus.eq(SellStatus.SELLING));
         builder.and(card.cardCategory.eq(REALTIME_SELL));
         builder.and(card.carrier.eq(filter.getCarrier()));
         builder.and(card.dataAmount.eq(filter.getDataAmount()));

--- a/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
+++ b/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
@@ -12,6 +12,8 @@ import org.springframework.context.annotation.Configuration;
 @EnableRabbit
 @Configuration
 public class RabbitMQConfig {
+
+
     /* ------------------- Topic : 실시간 서비스 전용 ------------------- */
     public static final String NOTIFICATION_EXCHANGE = "notification_exchange";
     public static final String NOTIFICATION_QUEUE    = "notification_queue";
@@ -60,6 +62,50 @@ public class RabbitMQConfig {
     }
 
 
+    /* ------------------- Fanout : 전체 브로드캐스트용(공지, 이벤트 등) ------------------- */
+    public static final String BROADCAST_EXCHANGE = "broadcast_exchange";
+    public static final String BROADCAST_QUEUE    = "broadcast_queue";
+
+    @Bean
+    public FanoutExchange broadcastExchange() {
+        return new FanoutExchange(BROADCAST_EXCHANGE);
+    }
+
+    @Bean
+    public Queue broadcastQueue() {
+        return new Queue(BROADCAST_QUEUE, false);
+    }
+
+    @Bean
+    public Binding broadcastBinding(FanoutExchange broadcastExchange, Queue broadcastQueue) {
+        return BindingBuilder
+                .bind(broadcastQueue)
+                .to(broadcastExchange);
+    }
+
+
+    /* ------------------- Fanout : 접속자 수 전용 브로드캐스트 ------------------- */
+    public static final String CONNECTED_USERS_EXCHANGE = "connected_users_exchange";
+    public static final String CONNECTED_USERS_QUEUE    = "connected_users_queue";
+
+    @Bean
+    public FanoutExchange connectedUsersExchange() {
+        return new FanoutExchange(CONNECTED_USERS_EXCHANGE);
+    }
+
+    @Bean
+    public Queue connectedUsersQueue() {
+        return new Queue(CONNECTED_USERS_QUEUE, false);
+    }
+
+    @Bean
+    public Binding connectedUsersBinding(FanoutExchange connectedUsersExchange, Queue connectedUsersQueue) {
+        return BindingBuilder
+                .bind(connectedUsersQueue)
+                .to(connectedUsersExchange);
+    }
+
+
     /* ------------------- Direct : SMS 전용 ------------------- */
     public static final String SMS_EXCHANGE     = "sms_exchange";
 
@@ -99,6 +145,7 @@ public class RabbitMQConfig {
                 .to(smsExchange)
                 .with(SMS_AUTH_ROUTING_KEY);
     }
+
 
     /* ------------------- 공통 설정 ------------------- */
     @Bean

--- a/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
+++ b/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
@@ -16,8 +16,8 @@ public class RabbitMQConfig {
 
     /* ------------------- Topic : 실시간 서비스 전용 ------------------- */
     public static final String NOTIFICATION_EXCHANGE = "notification_exchange";
-    public static final String NOTIFICATION_QUEUE    = "notification_queue";
-    public static final String ROUTING_KEY_PATTERN   = "notification.#";
+    public static final String NOTIFICATION_QUEUE = "notification_queue";
+    public static final String ROUTING_KEY_PATTERN = "notification.#";
 
     @Bean
     public TopicExchange notificationExchange() {
@@ -39,8 +39,8 @@ public class RabbitMQConfig {
 
     /* ------------------- Topic : 매칭 전용 ------------------- */
     public static final String MATCHING_NOTIFICATION_EXCHANGE = "matching_notification_exchange";
-    public static final String MATCHING_NOTIFICATION_QUEUE    = "matching_notification_queue";
-    public static final String MATCHING_ROUTING_KEY_PATTERN   = "matching.notification.#";
+    public static final String MATCHING_NOTIFICATION_QUEUE = "matching_notification_queue";
+    public static final String MATCHING_ROUTING_KEY_PATTERN = "matching.notification.#";
 
     @Bean
     public TopicExchange matchingNotificationExchange() {
@@ -64,7 +64,7 @@ public class RabbitMQConfig {
 
     /* ------------------- Fanout : 전체 브로드캐스트용(공지, 이벤트 등) ------------------- */
     public static final String BROADCAST_EXCHANGE = "broadcast_exchange";
-    public static final String BROADCAST_QUEUE    = "broadcast_queue";
+    public static final String BROADCAST_QUEUE = "broadcast_queue";
 
     @Bean
     public FanoutExchange broadcastExchange() {
@@ -86,7 +86,7 @@ public class RabbitMQConfig {
 
     /* ------------------- Fanout : 접속자 수 전용 브로드캐스트 ------------------- */
     public static final String CONNECTED_USERS_EXCHANGE = "connected_users_exchange";
-    public static final String CONNECTED_USERS_QUEUE    = "connected_users_queue";
+    public static final String CONNECTED_USERS_QUEUE = "connected_users_queue";
 
     @Bean
     public FanoutExchange connectedUsersExchange() {
@@ -107,15 +107,15 @@ public class RabbitMQConfig {
 
 
     /* ------------------- Direct : SMS 전용 ------------------- */
-    public static final String SMS_EXCHANGE     = "sms_exchange";
+    public static final String SMS_EXCHANGE = "sms_exchange";
 
     // 거래·알림 문자
-    public static final String SMS_TRADE_QUEUE       = "sms_trade_queue";
+    public static final String SMS_TRADE_QUEUE = "sms_trade_queue";
     public static final String SMS_TRADE_ROUTING_KEY = "sms.trade";
 
     // 인증 문자
-    public static final String SMS_AUTH_QUEUE        = "sms_auth_queue";
-    public static final String SMS_AUTH_ROUTING_KEY  = "sms.auth";
+    public static final String SMS_AUTH_QUEUE = "sms_auth_queue";
+    public static final String SMS_AUTH_ROUTING_KEY = "sms.auth";
 
     @Bean
     public DirectExchange smsExchange() {
@@ -146,6 +146,49 @@ public class RabbitMQConfig {
                 .with(SMS_AUTH_ROUTING_KEY);
     }
 
+    /* ------------------- Direct : 카드 목록 조회용 ------------------- */
+    public static final String CARD_LIST_EXCHANGE = "card_list_exchange";
+    public static final String CARD_LIST_QUEUE = "card_list_queue";
+    public static final String CARD_LIST_ROUTING_KEY = "card.list";
+
+    @Bean
+    public DirectExchange cardListExchange() {
+        return new DirectExchange(CARD_LIST_EXCHANGE);
+    }
+
+    @Bean
+    public Queue cardListQueue() {
+        return new Queue(CARD_LIST_QUEUE, false);
+    }
+
+    @Bean
+    public Binding cardListBinding(DirectExchange cardListExchange, Queue cardListQueue) {
+        return BindingBuilder.bind(cardListQueue)
+                .to(cardListExchange)
+                .with(CARD_LIST_ROUTING_KEY);
+    }
+
+    /* ------------------- Direct : 필터 조회용 ------------------- */
+    public static final String FILTER_EXCHANGE = "filter_exchange";
+    public static final String FILTER_QUEUE = "filter_queue";
+    public static final String FILTER_ROUTING_KEY = "filter.retrieve";
+
+    @Bean
+    public DirectExchange filterExchange() {
+        return new DirectExchange(FILTER_EXCHANGE);
+    }
+
+    @Bean
+    public Queue filterQueue() {
+        return new Queue(FILTER_QUEUE, false);
+    }
+
+    @Bean
+    public Binding filterBinding(DirectExchange filterExchange, Queue filterQueue) {
+        return BindingBuilder.bind(filterQueue)
+                .to(filterExchange)
+                .with(FILTER_ROUTING_KEY);
+    }
 
     /* ------------------- 공통 설정 ------------------- */
     @Bean

--- a/src/main/java/com/ureca/snac/notification/listener/NotificationListener.java
+++ b/src/main/java/com/ureca/snac/notification/listener/NotificationListener.java
@@ -2,6 +2,7 @@ package com.ureca.snac.notification.listener;
 
 import com.ureca.snac.board.dto.CardDto;
 import com.ureca.snac.config.RabbitMQConfig;
+import com.ureca.snac.trade.dto.RetrieveFilterDto;
 import com.ureca.snac.trade.dto.TradeDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,15 @@ public class NotificationListener {
     @RabbitListener(queues = RabbitMQConfig.BROADCAST_QUEUE)
     public void onBroadcast(String message) {
         messaging.convertAndSend("/topic/broadcast", message);
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.FILTER_QUEUE)
+    public void onFilter(RetrieveFilterDto dto) {
+        messaging.convertAndSendToUser(
+                dto.getUsername(),
+                "/queue/filters",
+                dto.getBuyerFilter()
+        );
     }
 
     public record WebSocketNotification(

--- a/src/main/java/com/ureca/snac/notification/listener/NotificationListener.java
+++ b/src/main/java/com/ureca/snac/notification/listener/NotificationListener.java
@@ -22,7 +22,7 @@ public class NotificationListener {
 
         messaging.convertAndSendToUser(
                 username,
-                "/queue/notifications",
+                "/queue/trade",
                 tradeDto
         );
     }
@@ -33,9 +33,19 @@ public class NotificationListener {
 
         messaging.convertAndSendToUser(
                 username,
-                "/queue/notifications",
+                "/queue/matching",
                 cardDto
         );
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.CONNECTED_USERS_QUEUE)
+    public void onConnectedUsersCount(Integer count) {
+        messaging.convertAndSend("/topic/connected-users", count);
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.BROADCAST_QUEUE)
+    public void onBroadcast(String message) {
+        messaging.convertAndSend("/topic/broadcast", message);
     }
 
     public record WebSocketNotification(

--- a/src/main/java/com/ureca/snac/notification/service/NotificationService.java
+++ b/src/main/java/com/ureca/snac/notification/service/NotificationService.java
@@ -1,9 +1,11 @@
 package com.ureca.snac.notification.service;
 
 import com.ureca.snac.board.dto.CardDto;
+import com.ureca.snac.trade.dto.RetrieveFilterDto;
 import com.ureca.snac.trade.dto.TradeDto;
 
 public interface NotificationService {
     void notify(String username, TradeDto tradeDto);
     void sendMatchingNotification(String username, CardDto cardDto);
+    void sendBuyFilterNotification(RetrieveFilterDto dto);
 }

--- a/src/main/java/com/ureca/snac/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/ureca/snac/notification/service/NotificationServiceImpl.java
@@ -4,19 +4,15 @@ import com.ureca.snac.board.dto.CardDto;
 import com.ureca.snac.member.Member;
 import com.ureca.snac.member.MemberRepository;
 import com.ureca.snac.member.exception.MemberNotFoundException;
-import com.ureca.snac.config.RabbitMQConfig;
-import com.ureca.snac.notification.dto.NotificationDTO;
-import com.ureca.snac.notification.entity.Notification;
 import com.ureca.snac.notification.repository.NotificationRepository;
+import com.ureca.snac.trade.dto.RetrieveFilterDto;
 import com.ureca.snac.trade.dto.TradeDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import static com.ureca.snac.config.RabbitMQConfig.*;
-import static com.ureca.snac.config.RabbitMQConfig.MATCHING_NOTIFICATION_EXCHANGE;
 
 @Slf4j
 @Service
@@ -44,6 +40,12 @@ public class NotificationServiceImpl implements NotificationService {
         log.info("매칭알림 MQ 발행: {} {}", username, cardDto);
         String routingKey = String.format("matching.notification.%s", username);
         rabbitTemplate.convertAndSend(MATCHING_NOTIFICATION_EXCHANGE, routingKey, cardDto);
+    }
+
+    @Override
+    public void sendBuyFilterNotification(RetrieveFilterDto dto) {
+        log.info("[필터 발행] username={} filterCount={}", dto.getUsername(), dto.getBuyerFilter().size());
+        rabbitTemplate.convertAndSend(FILTER_EXCHANGE, FILTER_ROUTING_KEY, dto);
     }
 
     private Member getMember(String email) {

--- a/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
@@ -66,6 +66,12 @@ public class MatchingController {
         matchingServiceFacade.confirmTrade(request, principal.getName());
     }
 
+    @MessageMapping("/filters")
+    public void sendAllBuyerFilters(Principal principal) {
+        log.info("[매칭] /filters 호출, 사용자: {}", principal.getName());
+        matchingServiceFacade.getBuyerFilters(principal.getName());
+    }
+
     @MessageExceptionHandler(CardAlreadyTradingException.class)
     @SendToUser("/queue/errors")
     public String handleCardAlreadyTradingException(CardAlreadyTradingException ex) {

--- a/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
@@ -5,6 +5,7 @@ import com.ureca.snac.board.exception.CardAlreadyTradingException;
 import com.ureca.snac.trade.controller.request.*;
 import com.ureca.snac.trade.service.MatchingServiceFacade;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class MatchingController {
@@ -23,38 +25,39 @@ public class MatchingController {
 
     @MessageMapping("/register-filter")
     public void registerBuyerFilter(@Payload BuyerFilterRequest filter, Principal principal) {
+        log.info("[매칭] /register-filter 호출, 사용자: {}, 필터: {}", principal.getName(), filter);
         matchingServiceFacade.registerBuyerFilterAndNotify(principal.getName(), filter);
     }
 
     @MessageMapping("/register-realtime-card")
     public void registerRealtimeCard(@Payload CreateRealTimeCardRequest request, Principal principal) {
-        String username = principal.getName();
-        matchingServiceFacade.createRealtimeCardAndNotifyBuyers(username, request);
+        log.info("[매칭] /register-realtime-card 호출, 사용자: {}, 요청: {}", principal.getName(), request);
+        matchingServiceFacade.createRealtimeCardAndNotifyBuyers(principal.getName(), request);
     }
 
     @MessageMapping("/connected-users")
     @SendToUser("/queue/connected-users")
     public Long getConnectedUserCount(Principal principal) {
+        log.info("[매칭] /connected-users 호출, 사용자: {}", principal.getName());
         return matchingServiceFacade.getConnectedUserCount();
     }
 
     @MessageMapping("/trade/create")
     public void createTrade(@Payload CreateRealTimeTradeRequest request, Principal principal) {
-        String username = principal.getName();
-
-        matchingServiceFacade.createTradeFromBuyer(request, username);
+        log.info("[거래] /trade/create 호출, 사용자: {}, 요청: {}", principal.getName(), request);
+        matchingServiceFacade.createTradeFromBuyer(request, principal.getName());
     }
 
     @MessageMapping("/trade/approve")
     public void approveTrade(@Payload TradeApproveRequest request, Principal principal) {
-        String username = principal.getName();
-        matchingServiceFacade.acceptTrade(request, username);
+        log.info("[거래] /trade/approve 호출, 사용자: {}, 요청: {}", principal.getName(), request);
+        matchingServiceFacade.acceptTrade(request, principal.getName());
     }
 
     @MessageMapping("/trade/payment")
     public void payTrade(@Payload CreateRealTimeTradePaymentRequest request, Principal principal) {
-        String username = principal.getName();
-        matchingServiceFacade.payTrade(request, username);
+        log.info("[거래] /trade/payment 호출, 사용자: {}, 요청: {}", principal.getName(), request);
+        matchingServiceFacade.payTrade(request, principal.getName());
     }
 
     @MessageExceptionHandler(CardAlreadyTradingException.class)

--- a/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/MatchingController.java
@@ -60,6 +60,12 @@ public class MatchingController {
         matchingServiceFacade.payTrade(request, principal.getName());
     }
 
+    @MessageMapping("/trade/confirm")
+    public void confirmTrade(@Payload ConfirmTradeRequest request, Principal principal) {
+        log.info("[거래] /trade/confirm 호출, 사용자: {}, 요청: {}", principal.getName(), request);
+        matchingServiceFacade.confirmTrade(request, principal.getName());
+    }
+
     @MessageExceptionHandler(CardAlreadyTradingException.class)
     @SendToUser("/queue/errors")
     public String handleCardAlreadyTradingException(CardAlreadyTradingException ex) {

--- a/src/main/java/com/ureca/snac/trade/controller/MatchingControllerMVC.java
+++ b/src/main/java/com/ureca/snac/trade/controller/MatchingControllerMVC.java
@@ -1,0 +1,33 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.trade.service.MatchingServiceFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.ureca.snac.common.BaseCode.TRADE_DATA_SENT_SUCCESS;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/matching")
+@RequiredArgsConstructor
+public class MatchingControllerMVC {
+
+    private final MatchingServiceFacade matchingServiceFacade;
+
+    @PatchMapping(value = "/{tradeId}/send-data", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<?>> sendTradeData(@PathVariable Long tradeId,
+                                                        @RequestPart("file") MultipartFile file,
+                                                        @AuthenticationPrincipal UserDetails userDetails) {
+        log.info("[거래 데이터 전송] PATCH /api/matching/{}/send-data 호출됨", tradeId);
+        matchingServiceFacade.sendTradeData(tradeId, file, userDetails.getUsername());
+
+        return ResponseEntity.ok(ApiResponse.ok(TRADE_DATA_SENT_SUCCESS));
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/controller/request/ConfirmTradeRequest.java
+++ b/src/main/java/com/ureca/snac/trade/controller/request/ConfirmTradeRequest.java
@@ -1,0 +1,9 @@
+package com.ureca.snac.trade.controller.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ConfirmTradeRequest {
+    private Long tradeId;
+}

--- a/src/main/java/com/ureca/snac/trade/dto/RetrieveFilterDto.java
+++ b/src/main/java/com/ureca/snac/trade/dto/RetrieveFilterDto.java
@@ -1,0 +1,15 @@
+package com.ureca.snac.trade.dto;
+
+import com.ureca.snac.trade.controller.request.BuyerFilterRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter @Setter
+@AllArgsConstructor
+public class RetrieveFilterDto {
+    private String username;
+    private Map<String, BuyerFilterRequest> buyerFilter;
+}

--- a/src/main/java/com/ureca/snac/trade/dto/TradeDto.java
+++ b/src/main/java/com/ureca/snac/trade/dto/TradeDto.java
@@ -12,6 +12,7 @@ import lombok.*;
 public class TradeDto {
     private Long id;
     private Long cardId;
+    private Integer sellerRatingScore;
     private String seller;
     private String buyer;
     private Carrier carrier;
@@ -26,6 +27,7 @@ public class TradeDto {
         return TradeDto.builder()
                 .id(trade.getId())
                 .cardId(trade.getCardId())
+                .sellerRatingScore(trade.getSeller().getRatingScore())
                 .seller(trade.getSeller().getEmail())
                 .buyer(trade.getBuyer().getEmail())
                 .carrier(trade.getCarrier())

--- a/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
@@ -6,10 +6,7 @@ import com.ureca.snac.board.dto.CardDto;
 import com.ureca.snac.board.entity.constants.PriceRange;
 import com.ureca.snac.board.service.CardService;
 import com.ureca.snac.notification.service.NotificationService;
-import com.ureca.snac.trade.controller.request.BuyerFilterRequest;
-import com.ureca.snac.trade.controller.request.CreateRealTimeTradePaymentRequest;
-import com.ureca.snac.trade.controller.request.CreateRealTimeTradeRequest;
-import com.ureca.snac.trade.controller.request.TradeApproveRequest;
+import com.ureca.snac.trade.controller.request.*;
 import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.service.interfaces.*;
 import lombok.RequiredArgsConstructor;
@@ -122,6 +119,16 @@ public class MatchingServiceFacade {
 
         // 구매자에게 확정 요청
         notificationService.notify(tradeDto.getBuyer(), tradeDto);
+    }
+
+    @Transactional
+    public void confirmTrade(ConfirmTradeRequest request, String username) {
+        Long tradeId = tradeProgressService.confirmTrade(request.getTradeId(), username);
+
+        TradeDto tradeDto = tradeQueryService.findByTradeId(tradeId);
+
+        // 판매자에게 확정 정보 제공
+        notificationService.notify(tradeDto.getSeller(), tradeDto);
     }
 
     // 조건 비교 함수

--- a/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
@@ -13,6 +13,7 @@ import com.ureca.snac.trade.controller.request.TradeApproveRequest;
 import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.service.interfaces.BuyFilterService;
 import com.ureca.snac.trade.service.interfaces.TradeInitiationService;
+import com.ureca.snac.trade.service.interfaces.TradeProgressService;
 import com.ureca.snac.trade.service.interfaces.TradeQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class MatchingServiceFacade {
     private final NotificationService notificationService;
     private final TradeInitiationService tradeInitiationService;
     private final TradeQueryService tradeQueryService;
+    private final TradeProgressService tradeProgressService;
     private final BuyFilterService buyFilterService;
 
     private final StringRedisTemplate redisTemplate;

--- a/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
@@ -7,6 +7,7 @@ import com.ureca.snac.board.entity.constants.PriceRange;
 import com.ureca.snac.board.service.CardService;
 import com.ureca.snac.notification.service.NotificationService;
 import com.ureca.snac.trade.controller.request.*;
+import com.ureca.snac.trade.dto.RetrieveFilterDto;
 import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.service.interfaces.*;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.ureca.snac.common.RedisKeyConstants.BUYER_FILTER_PREFIX;
@@ -52,6 +54,16 @@ public class MatchingServiceFacade {
         for (CardDto cardDto : cardDtoList) {
             notificationService.sendMatchingNotification(username, cardDto);
         }
+    }
+
+
+    public void getBuyerFilters(String username) {
+        Map<String, BuyerFilterRequest> allFilters = buyFilterService.findAllBuyerFilters();
+        RetrieveFilterDto dto = new RetrieveFilterDto(username, allFilters);
+
+        notificationService.sendBuyFilterNotification(dto);
+
+        log.info("[필터 발행] username={} filterCount={}", username, allFilters.size());
     }
 
     @Transactional

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/BuyFilterService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/BuyFilterService.java
@@ -2,6 +2,9 @@ package com.ureca.snac.trade.service.interfaces;
 
 import com.ureca.snac.trade.controller.request.BuyerFilterRequest;
 
+import java.util.Map;
+
 public interface BuyFilterService {
     void saveBuyerFilter(String username, BuyerFilterRequest filter);
+    Map<String, BuyerFilterRequest> findAllBuyerFilters();
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 알림 브로드캐스트 구조를 개선하고 각 기능에 맞게 채널을 분리했습니다.
2. 기존에 사용하는 거래 로직을 이용하여 거래 데이터 전송 기능을 구현했습니다. 
3. 기존에 사용하는 거래 로직을 이용하여 거래 확정 기능을 구현했습니다.
4. 매칭 조회시 판매중인 카드만 조회하도록 수정했습니다.
5. 실시간 매칭 입장시 구매자가 등록한 필터링을 조회할 수 있는 기능을 구현했습니다.

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 