### PR TITLE
refactor: 소셜 연동 중복 가입 못하게 리팩토링

### DIFF
--- a/src/main/java/com/ureca/snac/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/snac/auth/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                             "http://127.0.0.1:3000",
                             "https://docs.tosspayments.com",
                             "https://snac-app.com",
-
+                            "https://www.snac-app.com",
                             "https://develop.df83wi2m9axuw.amplifyapp.com",
                             "https://seungwoo.i234.me"
 


### PR DESCRIPTION
## 📝 변경 사항

- 기존에는 state를 무조건 로그인 시 이메일 추출 용도로만 썼다면, 이제는 JWT 파싱 성공 여부로 연동 플로우 vs 로그인 플로우를 분기
- 나중의 소셜 회원가입 대비 확장성 있는 리팩토링

## 🔍 변경 사항 세부 설명

**소셜 “연동” 플로우 분리**

isLinking == true인 경우,
이미 다른 계정에 해당 providerId가 연결되어 있는지(Repositoy의 findByNaverId/findByGoogleId/findByKakaoId) 체크
중복 연결 시 예외 발생
JWT에서 뽑은 이메일로 현재 계정(Member) 조회
member.updateSocialId(...) 호출해 연동 정보 저장
new CustomOAuth2User(...) 반환

**소셜 “로그인” 플로우 정비**

isLinking == false인 경우,
소셜 ID로 기존 회원 조회 (existingMember)
존재하면 곧바로 로그인 처리(CustomOAuth2User 반환)
없으면 다시 한 번 state를 JWT로 디코딩해 이메일 획득
이메일로 회원 조회 → updateSocialId(...) → 저장 → CustomOAuth2User 반환
그마저 실패하면 예외 발생

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 