### PR TITLE
feat: 마이페이지 첫 로딩

### DIFF
--- a/src/main/java/com/ureca/snac/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/ureca/snac/auth/filter/CustomLogoutFilter.java
@@ -84,8 +84,10 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
         Cookie cookie = new Cookie("refresh", null);
         cookie.setMaxAge(0);
-        cookie.setPath("/api");
-
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+//        cookie.setSecure(true);
+        cookie.setDomain("snac-app.com");
         response.addCookie(cookie);
 
 

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -174,6 +174,9 @@ public enum BaseCode {
     // 회원 - 예외
     MEMBER_NOT_FOUND("MEMBER_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
 
+    // 마이페이지 - 성공
+    MYPAGE_GET_SUCCESS("MYPAGE_GET_SUCCESS_200", HttpStatus.OK, "마이페이지 정보 조회에 성공했습니다."),
+
     // 비밀번호 변경 – 성공
     PASSWORD_CHANGED("PASSWORD_CHANGED_200", HttpStatus.OK, "비밀번호가 변경되었습니다."),
 

--- a/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepository.java
@@ -57,4 +57,13 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
             @Param("cursorId") Long cursorId,
             Pageable pageable);
+
+
+    /**
+     * 특정 사용자가 등록한 단골 수 조회
+     *
+     * @param fromMember 단골 목록 조회하고 싶은 회원
+     * @return 단골 수
+     */
+    Long countByFromMember(Member fromMember);
 }

--- a/src/main/java/com/ureca/snac/favorite/service/FavoriteService.java
+++ b/src/main/java/com/ureca/snac/favorite/service/FavoriteService.java
@@ -41,4 +41,14 @@ public interface FavoriteService {
      * @param toMemberId    삭제 당하는 회원 ID
      */
     void deleteFavorite(String fromUserEmail, Long toMemberId);
+
+
+
+    /**
+     * 내가 등록한 단골의 총 개수를 조회.
+     *
+     * @param fromUserEmail 검색할 주체 회원 이메일
+     * @return 등록된 단골 수
+     */
+    Long getFavoriteCount(String fromUserEmail);
 }

--- a/src/main/java/com/ureca/snac/favorite/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/ureca/snac/favorite/service/FavoriteServiceImpl.java
@@ -117,6 +117,14 @@ public class FavoriteServiceImpl implements FavoriteService {
         log.info("[단골 삭제] 얘가 쟤를 삭제 : {} -> {}", fromMember.getId(), toMemberId);
     }
 
+    @Override
+    public Long getFavoriteCount(String fromUserEmail) {
+        Member fromMember = findMemberByEmail(fromUserEmail);
+        Long count = favoriteRepository.countByFromMember(fromMember);
+        log.info("[단골 수 조회] 회원ID: {}, count: {}", fromMember.getId(), count);
+        return count;
+    }
+
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);

--- a/src/main/java/com/ureca/snac/mypage/MyPageController.java
+++ b/src/main/java/com/ureca/snac/mypage/MyPageController.java
@@ -2,6 +2,7 @@ package com.ureca.snac.mypage;
 
 import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.favorite.service.FavoriteService;
 import com.ureca.snac.mypage.dto.MyPageResponse;
 import com.ureca.snac.mypage.service.MyPageService;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +18,18 @@ import static com.ureca.snac.common.BaseCode.MYPAGE_GET_SUCCESS;
 public class MyPageController implements MyPageControllerSwagger {
 
     private final MyPageService myPageService;
+    private final FavoriteService favoriteService;
 
     @Override
     public ResponseEntity<ApiResponse<MyPageResponse>> getMyPageInfo(CustomUserDetails userDetails) {
         String email = userDetails.getUsername();
-        MyPageResponse response = myPageService.getMyPageInfo(email);
+        MyPageResponse myPageInfo = myPageService.getMyPageInfo(email);
+        Long favoriteCount = favoriteService.getFavoriteCount(email);
+
+        MyPageResponse response = myPageInfo.toBuilder()
+                .favoriteCount(favoriteCount)
+                .build();
+
         return ResponseEntity.ok(ApiResponse.of(MYPAGE_GET_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ureca/snac/mypage/MyPageController.java
+++ b/src/main/java/com/ureca/snac/mypage/MyPageController.java
@@ -1,0 +1,27 @@
+package com.ureca.snac.mypage;
+
+import com.ureca.snac.auth.dto.CustomUserDetails;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.mypage.dto.MyPageResponse;
+import com.ureca.snac.mypage.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.ureca.snac.common.BaseCode.MYPAGE_GET_SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MyPageController implements MyPageControllerSwagger {
+
+    private final MyPageService myPageService;
+
+    @Override
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPageInfo(CustomUserDetails userDetails) {
+        String email = userDetails.getUsername();
+        MyPageResponse response = myPageService.getMyPageInfo(email);
+        return ResponseEntity.ok(ApiResponse.of(MYPAGE_GET_SUCCESS, response));
+    }
+}

--- a/src/main/java/com/ureca/snac/mypage/MyPageControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/mypage/MyPageControllerSwagger.java
@@ -1,0 +1,28 @@
+package com.ureca.snac.mypage;
+
+import com.ureca.snac.auth.dto.CustomUserDetails;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.mypage.dto.MyPageResponse;
+import com.ureca.snac.swagger.annotation.UserInfo;
+import com.ureca.snac.swagger.annotation.error.ErrorCode401;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "마이페이지", description = "마이페이지 관련 API")
+@RequestMapping("/api")
+public interface MyPageControllerSwagger {
+
+    @GetMapping("/mypage")
+    @Operation(summary = "마이페이지 첫 화면", description = "마이페이지의 첫 화면에 필요한 정보들을 반환합니다.")
+    @SecurityRequirement(name = "Authorization")
+    @ApiSuccessResponse(description = "마이페이지 정보 조회 성공")
+    @ErrorCode401
+    @ErrorCode404(description = "해당 회원을 찾을 수 없습니다.")
+    ResponseEntity<ApiResponse<MyPageResponse>> getMyPageInfo(@UserInfo CustomUserDetails userDetails);
+}

--- a/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
+++ b/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class MyPageResponse {
     private String name;
     private String phone;
@@ -18,6 +18,7 @@ public class MyPageResponse {
     private boolean isNaverConnected;
     private boolean isGoogleConnected;
     private boolean isKakaoConnected;
+    private Long favoriteCount;
 
     public static MyPageResponse from(Member member) {
         return MyPageResponse.builder()

--- a/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
+++ b/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
@@ -1,0 +1,34 @@
+package com.ureca.snac.mypage.dto;
+
+import com.ureca.snac.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyPageResponse {
+    private String name;
+    private String phone;
+    private LocalDate birthDate;
+    private int score;
+    private LocalDateTime nicknameUpdatedAt;
+    private boolean isNaverConnected;
+    private boolean isGoogleConnected;
+    private boolean isKakaoConnected;
+
+    public static MyPageResponse from(Member member) {
+        return MyPageResponse.builder()
+                .name(member.getName())
+                .phone(member.getPhone())
+                .birthDate(member.getBirthDate())
+                .score(member.getRatingScore())
+                .nicknameUpdatedAt(member.getNicknameUpdatedAt())
+                .isNaverConnected(member.getNaverId() != null)
+                .isGoogleConnected(member.getGoogleId() != null)
+                .isKakaoConnected(member.getKakaoId() != null)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
+++ b/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
@@ -27,9 +27,9 @@ public class MyPageResponse {
                 .birthDate(member.getBirthDate())
                 .score(member.getRatingScore())
                 .nicknameUpdatedAt(member.getNicknameUpdatedAt())
-                .isNaverConnected(member.getNaverId() != null)
-                .isGoogleConnected(member.getGoogleId() != null)
-                .isKakaoConnected(member.getKakaoId() != null)
+                .isNaverConnected(member.getNaverId() != null && !member.getNaverId().isEmpty())
+                .isGoogleConnected(member.getGoogleId() != null && !member.getGoogleId().isEmpty())
+                .isKakaoConnected(member.getKakaoId() != null && !member.getKakaoId().isEmpty())
                 .build();
     }
 }

--- a/src/main/java/com/ureca/snac/mypage/service/MyPageService.java
+++ b/src/main/java/com/ureca/snac/mypage/service/MyPageService.java
@@ -1,0 +1,7 @@
+package com.ureca.snac.mypage.service;
+
+import com.ureca.snac.mypage.dto.MyPageResponse;
+
+public interface MyPageService {
+    MyPageResponse getMyPageInfo(String email);
+}

--- a/src/main/java/com/ureca/snac/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/com/ureca/snac/mypage/service/MyPageServiceImpl.java
@@ -25,4 +25,5 @@ public class MyPageServiceImpl implements MyPageService {
 
 
 
+
 }

--- a/src/main/java/com/ureca/snac/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/com/ureca/snac/mypage/service/MyPageServiceImpl.java
@@ -1,0 +1,28 @@
+package com.ureca.snac.mypage.service;
+
+import com.ureca.snac.member.Member;
+import com.ureca.snac.member.MemberRepository;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.mypage.dto.MyPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageServiceImpl implements MyPageService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MyPageResponse getMyPageInfo(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+        return MyPageResponse.from(member);
+    }
+
+
+
+
+}


### PR DESCRIPTION
## 📝 변경 사항

1. 로그아웃 필터의 쿠키 설정 수정

2. 마이페이지 조회 API 구현

3. 마이페이지에 단골 수 조회 기능 추가

4. 마이페이지에서 소셜 계정 연결 여부 체크 로직 개선

## 🔍 변경 사항 세부 설명

### 1. 로그아웃 필터 쿠키 설정 수정 (fix)
로그아웃 시 쿠키의 path를 /로 변경하여 전체 경로에서 쿠키 제거 가능하도록 수정

HttpOnly 옵션을 활성화하여 보안 강화

domain 설정을 추가하여 쿠키의 유효 도메인 명시

### 2. 마이페이지 조회 API 구현 (feat)
MyPageController, MyPageService, MyPageResponse DTO 등 신규 추가

사용자 이름, 생년월일, 닉네임 변경일, 점수 등 기본 정보 반환

API 응답 코드 정의 및 예외 처리 구조 포함

### 3. 단골 수 조회 기능 통합 (feat)
FavoriteService에 단골 수 조회용 메서드 추가

마이페이지 응답 DTO에 favoriteCount 필드 포함

### 4. 소셜 계정 연결 여부 로직 개선 (fix)
Naver, Google, Kakao 연결 여부 판단 시 null 뿐 아니라 빈 문자열("")도 연결되지 않은 것으로 간주

보다 정확한 연결 여부 판단 가능

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 