### PR TITLE
[feat] 실시간 거래 매칭 예외 케이스 수정

### DIFF
--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -218,6 +218,7 @@ public enum BaseCode {
     TRADE_SCROLL_SUCCESS("TRADE_SCROLL_SUCCESS_200", HttpStatus.OK, "거래 내역 조회에 성공하였습니다."),
     TRADE_PROGRESS_COUNT_SUCCESS("TRADE_PROGRESS_COUNT_SUCCESS_200", HttpStatus.OK, "진행 중인 거래 건수를 성공적으로 조회했습니다."),
     TRADE_STATISTICS_READ_SUCCESS("STATISTICS_READ_SUCCESS_200", HttpStatus.OK, "거래 통계 데이터를 성공적으로 조회했습니다."),
+    TRADE_READ_SUCCESS("TRADE_READ_SUCCESS_200", HttpStatus.OK, "거래 정보를 성공적으로 조회했습니다."),
 
     // 거래 - 실패
     TRADE_NOT_FOUND("TRADE_NOT_FOUND_404", HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
@@ -8,6 +8,7 @@ import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.TradeFacade;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
 import com.ureca.snac.trade.service.response.ScrollTradeResponse;
+import com.ureca.snac.trade.service.response.TradeIdResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,25 +46,25 @@ public class BasicTradeController implements BasicTradeControllerSwagger {
     public ResponseEntity<ApiResponse<?>> createSellTrade(@RequestBody CreateTradeRequest createTradeRequest,
                                                           @AuthenticationPrincipal UserDetails userDetails) {
 
-        tradeFacade.createSellTrade(createTradeRequest, userDetails.getUsername());
+        Long sellTradeId = tradeFacade.createSellTrade(createTradeRequest, userDetails.getUsername());
 
-        return ResponseEntity.ok(ApiResponse.ok(TRADE_CREATE_SUCCESS));
+        return ResponseEntity.ok(ApiResponse.of(TRADE_CREATE_SUCCESS, new TradeIdResponse(sellTradeId)));
     }
 
     @PostMapping("/buy")
     public ResponseEntity<ApiResponse<?>> createBuyTrade(@RequestBody CreateTradeRequest createTradeRequest,
                                                          @AuthenticationPrincipal UserDetails userDetails) {
-        tradeFacade.createBuyTrade(createTradeRequest, userDetails.getUsername());
+        Long buyTradeId = tradeFacade.createBuyTrade(createTradeRequest, userDetails.getUsername());
 
-        return ResponseEntity.ok(ApiResponse.ok(TRADE_CREATE_SUCCESS));
+        return ResponseEntity.ok(ApiResponse.of(TRADE_CREATE_SUCCESS, new TradeIdResponse(buyTradeId)));
     }
 
     @PostMapping("/buy/accept")
     public ResponseEntity<ApiResponse<?>> acceptBuyRequest(@RequestBody ClaimBuyRequest claimBuyRequest,
                                                            @AuthenticationPrincipal UserDetails userDetails) {
-        tradeFacade.acceptBuyRequest(claimBuyRequest, userDetails.getUsername());
+        Long acceptedTradeId = tradeFacade.acceptBuyRequest(claimBuyRequest, userDetails.getUsername());
         return ResponseEntity
-                .ok(ApiResponse.ok(TRADE_ACCEPT_SUCCESS));
+                .ok(ApiResponse.of(TRADE_ACCEPT_SUCCESS, new TradeIdResponse(acceptedTradeId)));
     }
 
     @PatchMapping(value = "/{tradeId}/send-data", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
@@ -9,6 +9,7 @@ import com.ureca.snac.trade.service.TradeFacade;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
 import com.ureca.snac.trade.service.response.ScrollTradeResponse;
 import com.ureca.snac.trade.service.response.TradeIdResponse;
+import com.ureca.snac.trade.service.response.TradeResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,6 +92,14 @@ public class BasicTradeController implements BasicTradeControllerSwagger {
                                                                          @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok(ApiResponse.of(TRADE_SCROLL_SUCCESS,
                 tradeFacade.scrollTrades(userDetails.getUsername(), side, size, cursorId)));
+    }
+
+    @GetMapping("/{tradeId}")
+    public ResponseEntity<ApiResponse<TradeResponse>> retrieveTrade(@PathVariable("tradeId") Long tradeId,
+                                                                    @AuthenticationPrincipal UserDetails userDetails) {
+
+        return ResponseEntity.ok(ApiResponse.of(TRADE_READ_SUCCESS,
+                tradeFacade.getTradeById(tradeId, userDetails.getUsername())));
     }
 
     @PatchMapping("/{tradeId}/cancel/request")

--- a/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
@@ -21,6 +21,9 @@ public interface TradeRepository extends JpaRepository<Trade, Long>, CustomTrade
     Optional<Trade> findByCardIdAndBuyerIdAndStatusNot(Long cardId, Long buyerId, TradeStatus status);
     Optional<Trade> findByIdAndStatus(Long id, TradeStatus status);   // 수락용
 
+    @Query("SELECT t FROM Trade t WHERE t.id = :id AND (t.buyer = :member OR t.seller = :member)")
+    Optional<Trade> findByIdAndParticipant(@Param("id") Long id, @Param("member") Member member);
+
     @EntityGraph(attributePaths = {"seller", "buyer"})
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Trade> findLockedById(Long tradeId);

--- a/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
@@ -163,7 +163,7 @@ public class MatchingServiceFacade {
     // 실시간 매칭 - 구매자가 거래를 확정 ( Status == COMPLETED, Card == SOLD_OUT )
     @Transactional
     public void confirmTrade(ConfirmTradeRequest request, String username) {
-        Long tradeId = tradeProgressService.confirmTrade(request.getTradeId(), username);
+        Long tradeId = tradeProgressService.confirmTrade(request.getTradeId(), username, false);
 
         TradeDto tradeDto = tradeQueryService.findByTradeId(tradeId);
 

--- a/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
@@ -10,6 +10,7 @@ import com.ureca.snac.trade.entity.CancelReason;
 import com.ureca.snac.trade.service.interfaces.*;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
 import com.ureca.snac.trade.service.response.ScrollTradeResponse;
+import com.ureca.snac.trade.service.response.TradeResponse;
 import com.ureca.snac.trade.support.TradeMessageBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -82,6 +83,10 @@ public class TradeFacade {
 
         TradeMessageDto tradeMessageDto = tradeMessageBuilder.buildTradeMessage(confirmTradeId);
         rabbitTemplate.convertAndSend(RabbitMQConfig.SMS_EXCHANGE, RabbitMQConfig.SMS_TRADE_ROUTING_KEY, tradeMessageDto);
+    }
+
+    public TradeResponse getTradeById(Long tradeId, String username) {
+        return tradeQueryService.getTradeById(tradeId, username);
     }
 
     public ScrollTradeResponse scrollTrades(String username, TradeSide side, int size, Long lastTradeId) {

--- a/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
@@ -55,11 +55,13 @@ public class TradeFacade {
     }
 
     @Transactional
-    public void acceptBuyRequest(ClaimBuyRequest claimBuyRequest, String username) {
+    public Long acceptBuyRequest(ClaimBuyRequest claimBuyRequest, String username) {
         Long tradeId = tradeInitiationService.acceptBuyRequest(claimBuyRequest, username);
 
         TradeMessageDto tradeMessageDto = tradeMessageBuilder.buildTradeMessage(tradeId);
         rabbitTemplate.convertAndSend(RabbitMQConfig.SMS_EXCHANGE, RabbitMQConfig.SMS_TRADE_ROUTING_KEY, tradeMessageDto);
+
+        return tradeId;
     }
 
     // === TradeProgressService === //

--- a/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
@@ -79,7 +79,7 @@ public class TradeFacade {
 
     @Transactional
     public void confirmTrade(Long tradeId, String username) {
-        Long confirmTradeId = tradeProgressService.confirmTrade(tradeId, username);
+        Long confirmTradeId = tradeProgressService.confirmTrade(tradeId, username, true);
 
         TradeMessageDto tradeMessageDto = tradeMessageBuilder.buildTradeMessage(confirmTradeId);
         rabbitTemplate.convertAndSend(RabbitMQConfig.SMS_EXCHANGE, RabbitMQConfig.SMS_TRADE_ROUTING_KEY, tradeMessageDto);

--- a/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
@@ -56,24 +56,33 @@ public class TradeProgressServiceImpl implements TradeProgressService {
         return trade.getId();
     }
 
+    // 해당 확정 메서드는 현재 실시간 매칭과 일반 매칭에 사용합니다.
+    // 마지막에 상대방이 나간 경우 카드가 삭제되는 문제가 발생하여 거래가 확정이 안되는 문제가 있어 파라미터 hasCard를 추가합니다.
+    // 일반 매칭 hasCard == true, 실시간 매칭 == false
     @Override
     @Transactional
-    public Long confirmTrade(Long tradeId, String username) {
+    public Long confirmTrade(Long tradeId, String username, Boolean hasCard) {
         Trade trade = tradeSupport.findLockedTrade(tradeId);
         Member buyer = tradeSupport.findMember(username);
 //        Wallet wallet = tradeSupport.findLockedWallet(trade.getSeller().getId());
-        Card card = tradeSupport.findLockedCard(trade.getCardId());
         Member seller = trade.getSeller();
 
         trade.confirm(buyer); // 거래 상태를 확정으로 변경
-        card.changeSellStatus(SOLD_OUT); // 카드 상태를 판매 완료로 변경
+
+        if (hasCard) {
+            Card card = tradeSupport.findLockedCard(trade.getCardId());
+            card.changeSellStatus(SOLD_OUT); // 카드 상태를 판매 완료로 변경
+        } else {
+            // 실시간 매칭에서는 거래가 끝난 경우 카드는 필요 없으므로 삭제
+            cardRepository.deleteById(trade.getCardId());
+        }
 
         long amountToDeposit = trade.getPriceGb();
         long finalBalance = walletService.depositMoney(seller.getId(),
                 amountToDeposit);
 
-        String title = String.format("%s %dGB 판매 대금", card.getCarrier().name(),
-                card.getDataAmount());
+        String title = String.format("%s %dGB 판매 대금", trade.getCarrier().name(),
+                trade.getDataAmount());
         AssetChangedEvent event = assetChangedEventFactory.createForSell(
                 seller.getId(), trade.getId(), title,
                 amountToDeposit, finalBalance

--- a/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
@@ -6,12 +6,7 @@ import com.ureca.snac.asset.service.AssetHistoryEventPublisher;
 import com.ureca.snac.board.entity.Card;
 import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.member.Member;
-import com.ureca.snac.trade.controller.request.CancelBuyRequest;
-import com.ureca.snac.trade.controller.request.CancelRealTimeTradeRequest;
-import com.ureca.snac.trade.dto.TradeDto;
-import com.ureca.snac.trade.entity.CancelReason;
 import com.ureca.snac.trade.entity.Trade;
-import com.ureca.snac.trade.exception.TradeNotFoundException;
 import com.ureca.snac.trade.exception.TradeSendPermissionDeniedException;
 import com.ureca.snac.trade.exception.TradeStatusMismatchException;
 import com.ureca.snac.trade.repository.TradeRepository;
@@ -23,11 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static com.ureca.snac.board.entity.constants.SellStatus.SOLD_OUT;
-import static com.ureca.snac.trade.entity.CancelReason.*;
-import static com.ureca.snac.trade.entity.TradeStatus.*;
+import static com.ureca.snac.trade.entity.TradeStatus.DATA_SENT;
+import static com.ureca.snac.trade.entity.TradeStatus.PAYMENT_CONFIRMED;
 
 @Slf4j
 @Service

--- a/src/main/java/com/ureca/snac/trade/service/TradeQueryServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeQueryServiceImpl.java
@@ -64,10 +64,21 @@ public class TradeQueryServiceImpl implements TradeQueryService {
                 List.of(DATA_SENT, PAYMENT_CONFIRMED)));
     }
 
+    // 메시지 알림용 trade 반환 메서드
     @Override
     public TradeDto findByTradeId(Long tradeId) {
         return tradeRepository.findById(tradeId)
                 .map(TradeDto::from)
+                .orElseThrow(TradeNotFoundException::new);
+    }
+
+    // 일반 거래에 사용하는 trade 반환 메서드
+    @Override
+    public TradeResponse getTradeById(Long tradeId, String username) {
+        Member member = tradeSupport.findMember(username);
+
+        return tradeRepository.findByIdAndParticipant(tradeId, member)
+                .map(TradeResponse::from)
                 .orElseThrow(TradeNotFoundException::new);
     }
 

--- a/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
+++ b/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
@@ -95,15 +95,15 @@ public class WebSocketTradeEventListener {
             // 2) 필터 조건 삭제
             buyFilterService.deleteBuyerFilterByUsername(username);
 
-            // 3) DB 카드 삭제
+            // 3) 강제 종료 처리
+            forceCancelRealTimeTrades(username);
+
+            // 4) DB 카드 삭제
             List<CardDto> cards = cardService.findByMemberUsernameAndSellStatusesAndCardCategory(username, List.of(SELLING, TRADING), REALTIME_SELL);
             for (CardDto card : cards) {
                 cardService.deleteCardByRealTime(username, card.getCardId());
                 log.info("판매자 카드 삭제: {} (cardId={})", username, card.getCardId());
             }
-
-            // 4) 강제 종료 처리
-            forceCancelRealTimeTrades(username);
 
             // 5) 최종 접속자 수 브로드캐스트
             broadcastUserCount();

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/TradeProgressService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/TradeProgressService.java
@@ -1,13 +1,6 @@
 package com.ureca.snac.trade.service.interfaces;
 
 
-import com.ureca.snac.trade.controller.request.CancelBuyRequest;
-import com.ureca.snac.trade.controller.request.CancelRealTimeTradeRequest;
-import com.ureca.snac.trade.dto.TradeDto;
-import com.ureca.snac.trade.entity.CancelReason;
-
-import java.util.List;
-
 public interface TradeProgressService {
 
     /**
@@ -24,7 +17,7 @@ public interface TradeProgressService {
      * @param tradeId  거래 ID
      * @param username 요청 판매자 이메일
      */
-    Long confirmTrade(Long tradeId, String username);
+    Long confirmTrade(Long tradeId, String username, Boolean hasCard);
 
 //    List<TradeDto> cancelOtherTradesOfCard(Long cardId, Long acceptedTradeId);
 //

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/TradeQueryService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/TradeQueryService.java
@@ -4,6 +4,7 @@ import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
 import com.ureca.snac.trade.service.response.ScrollTradeResponse;
+import com.ureca.snac.trade.service.response.TradeResponse;
 
 import java.util.List;
 
@@ -36,6 +37,8 @@ public interface TradeQueryService {
     ProgressTradeCountResponse countBuyingProgress(String username);
 
     TradeDto findByTradeId(Long tradeId);
+
+    TradeResponse getTradeById(Long tradeId, String username);
 
     List<TradeDto> findBuyerRealTimeTrade(String buyerUsername);
 

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeIdResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeIdResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.trade.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TradeIdResponse {
+    private Long tradeId;
+}

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
@@ -26,6 +26,19 @@ public class TradeResponse {
 
     private LocalDateTime createdAt;
 
+    public static TradeResponse from(Trade trade) {
+        return new TradeResponse(
+                trade.getId(),
+                trade.getPriceGb(),
+                trade.getDataAmount(),
+                null,
+                trade.getCarrier(),
+                trade.getCancelReason(),
+                trade.getStatus(),
+                trade.getCreatedAt()
+        );
+    }
+
     public static TradeResponse from(Trade trade, TradeSide side) {
         String phoneToShow = null;
 


### PR DESCRIPTION
## 📝 변경 사항

1. 거래 시작 시 tradeId를 반환
2. 거래 조회를 위한 api 추가
3. 거래 수락 전 카드가 삭제되는 문제 수정
4. 실시간 매칭 거래 구매 확정 시 카드가 삭제되도록 처리
5. 판매자 강제종료 후 거래 정리 로직이 동작하지 않는 문제 해결

## 🔍 변경 사항 세부 설명

- 거래 수락 전 카드가 삭제되는 문제 수정
  - 판매자의 글이 삭제되면 판매자가 글을 다시 작성해야 하므로 ux 적으로 문제가 있다고 판단하여 수정 함
  
- 실시간 매칭 거래 구매 확정 시 카드가 삭제되도록 처리
  - 실시간 매칭이 종료되면 해당 카드는 사용하지 않는 데이터이므로 제거  

- 판매자 강제종료 후 거래 정리 로직이 동작하지 않는 문제는 제거 플로우가 카드를 제거 후 거래를 제거하여 문제가 발생

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 