### PR TITLE
[feat, fix] 거래내역 조회 및 카드 관련 기능 보완

### DIFF
--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -9,6 +9,8 @@ import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
 import com.ureca.snac.board.entity.constants.PriceRange;
 import com.ureca.snac.board.service.CardService;
+import com.ureca.snac.board.service.response.CardResponse;
+import com.ureca.snac.board.service.response.CreateCardResponse;
 import com.ureca.snac.board.service.response.ScrollCardResponse;
 import com.ureca.snac.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,12 +34,12 @@ public class CardController implements CardControllerSwagger{
 
     @Override
     @PostMapping
-    public ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request,
-                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        cardService.createCard(customUserDetails.getUsername(), request);
+    public ResponseEntity<ApiResponse<CreateCardResponse>> createCard(@Validated @RequestBody CreateCardRequest request,
+                                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long cardId = cardService.createCard(customUserDetails.getUsername(), request);
 
         return ResponseEntity.status(CARD_CREATE_SUCCESS.getStatus())
-                .body(ApiResponse.ok(CARD_CREATE_SUCCESS));
+                .body(ApiResponse.of(CARD_CREATE_SUCCESS, new CreateCardResponse(cardId)));
     }
 
     @Override
@@ -81,5 +83,11 @@ public class CardController implements CardControllerSwagger{
     @GetMapping("/dev")
     public ResponseEntity<ApiResponse<List<CardDto>>> getDevCardList() {
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, cardService.findAllDevCard()));
+    }
+
+    @Override
+    @GetMapping("/{cardId}")
+    public ResponseEntity<ApiResponse<CardResponse>> getCardById(@PathVariable("cardId") Long cardId) {
+        return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, cardService.findCardById(cardId)));
     }
 }

--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -90,4 +90,11 @@ public class CardController implements CardControllerSwagger{
     public ResponseEntity<ApiResponse<CardResponse>> getCardById(@PathVariable("cardId") Long cardId) {
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, cardService.findCardById(cardId)));
     }
+
+    @Override
+    @GetMapping("/favorite/{email}")
+    public ResponseEntity<ApiResponse<List<CardResponse>>> getCardsByFavoriteUser(@PathVariable("email") String email) {
+        List<CardResponse> response = cardService.getSellingCardsByEmail(email);
+        return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, response));
+    }
 }

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -114,4 +114,12 @@ public interface CardControllerSwagger {
     @ApiSuccessResponse(description = "카드 상세 정보 조회 성공")
     @GetMapping("/{cardId}")
     ResponseEntity<ApiResponse<CardResponse>> getCardById(@PathVariable("cardId") Long cardId);
+
+    @Operation(
+            summary = "단골 사용자의 판매 중인 카드 목록 조회",
+            description = "email을 기반으로 해당 사용자가 등록한 판매 중인 카드 목록을 조회합니다."
+    )
+    @ApiSuccessResponse(description = "조회 성공")
+    @ErrorCode404(description = "사용자가 존재하지 않음")
+    ResponseEntity<ApiResponse<List<CardResponse>>> getCardsByFavoriteUser(@PathVariable("email") String email);
 }

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -9,6 +9,8 @@ import com.ureca.snac.board.dto.CardDto;
 import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
 import com.ureca.snac.board.entity.constants.PriceRange;
+import com.ureca.snac.board.service.response.CardResponse;
+import com.ureca.snac.board.service.response.CreateCardResponse;
 import com.ureca.snac.board.service.response.ScrollCardResponse;
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.swagger.annotation.error.ErrorCode400;
@@ -30,6 +32,8 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.ureca.snac.common.BaseCode.CARD_READ_SUCCESS;
+
 
 @Tag(name = "판매글/구매글 관리", description = "판매글(SELL), 구매글(BUY) 등록, 조회, 삭제, 수정 기능 제공")
 @SecurityRequirement(name = "Authorization")
@@ -43,7 +47,8 @@ public interface CardControllerSwagger {
     @ErrorCode400(description = "등록 실패 - 입력값이 잘못되었습니다.")
     @ErrorCode401(description = "인증되지 않은 사용자 접근")
     @PostMapping
-    ResponseEntity<ApiResponse<?>> createCard(@Validated @RequestBody CreateCardRequest request, @AuthenticationPrincipal CustomUserDetails customUserDetails);
+    ResponseEntity<ApiResponse<CreateCardResponse>> createCard(@Validated @RequestBody CreateCardRequest request,
+                                                               @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
     @Operation(
             summary = "판매글 또는 구매글 수정",
@@ -100,4 +105,13 @@ public interface CardControllerSwagger {
             description = "등록된 카드 목록 전체를 조회합니다."
     )
     ResponseEntity<ApiResponse<List<CardDto>>> getDevCardList();
+
+
+    @Operation(
+            summary = "카드 상세 조회",
+            description = "ID를 통해 등록된 카드의 상세 정보를 조회합니다."
+    )
+    @ApiSuccessResponse(description = "카드 상세 정보 조회 성공")
+    @GetMapping("/{cardId}")
+    ResponseEntity<ApiResponse<CardResponse>> getCardById(@PathVariable("cardId") Long cardId);
 }

--- a/src/main/java/com/ureca/snac/board/repository/CardRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepository.java
@@ -25,4 +25,6 @@ public interface CardRepository extends JpaRepository<Card, Long>, CardRepositor
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<Card> findLockedByMemberAndSellStatusInAndCardCategory(Member member, List<SellStatus> sellStatuses, CardCategory cardCategory);
+
+    List<Card> findByMemberAndSellStatusOrderByUpdatedAtDesc(Member member, SellStatus sellStatus);
 }

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -68,7 +68,14 @@ public interface CardService {
 
     List<CardDto> findByMemberUsernameAndSellStatusesAndCardCategory(String username, List<SellStatus> sellStatuses, CardCategory cardCategory);
 
+    /**
+     * 카드를 PK(id) 기준으로 조회합니다.
+     *
+     * @param cardId PK
+     * @return 카드 정보
+     */
     CardResponse findCardById(Long cardId);
+    List<CardResponse> getSellingCardsByEmail(String email);
     List<CardDto> findAllDevCard();
 }
 

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -9,6 +9,7 @@ import com.ureca.snac.board.entity.constants.CardCategory;
 import com.ureca.snac.board.entity.constants.Carrier;
 import com.ureca.snac.board.entity.constants.PriceRange;
 import com.ureca.snac.board.entity.constants.SellStatus;
+import com.ureca.snac.board.service.response.CardResponse;
 import com.ureca.snac.board.service.response.ScrollCardResponse;
 import com.ureca.snac.trade.controller.request.BuyerFilterRequest;
 
@@ -67,6 +68,7 @@ public interface CardService {
 
     List<CardDto> findByMemberUsernameAndSellStatusesAndCardCategory(String username, List<SellStatus> sellStatuses, CardCategory cardCategory);
 
+    CardResponse findCardById(Long cardId);
     List<CardDto> findAllDevCard();
 }
 

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -53,8 +53,7 @@ public class CardServiceImpl implements CardService {
 
     @Transactional
     public CardDto createRealtimeCard(String username, CreateRealTimeCardRequest request) {
-        Member member = memberRepository.findByEmail(username)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
 
         Card card = Card.builder()
                 .member(member)
@@ -175,6 +174,16 @@ public class CardServiceImpl implements CardService {
         return cardRepository.findById(cardId)
                 .map(CardResponse::from)
                 .orElseThrow(CardNotFoundException::new);
+    }
+
+    @Override
+    public List<CardResponse> getSellingCardsByEmail(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+
+        return cardRepository.findByMemberAndSellStatusOrderByUpdatedAtDesc(member, SellStatus.SELLING)
+                .stream()
+                .map(CardResponse::from)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -171,6 +171,13 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
+    public CardResponse findCardById(Long cardId) {
+        return cardRepository.findById(cardId)
+                .map(CardResponse::from)
+                .orElseThrow(CardNotFoundException::new);
+    }
+
+    @Override
     public List<CardDto> findAllDevCard() {
         return cardRepository.findAll()
                 .stream()

--- a/src/main/java/com/ureca/snac/board/service/response/CardResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/CardResponse.java
@@ -16,6 +16,7 @@ public class CardResponse {
     private Long id;
     private String name;
     private String email;
+    private Integer ratingScore;
     private SellStatus sellStatus;
     private CardCategory cardCategory;
     private Carrier carrier;
@@ -29,6 +30,7 @@ public class CardResponse {
                 card.getId(),
                 card.getMember().getName(),
                 card.getMember().getEmail(),
+                card.getMember().getRatingScore(),
                 card.getSellStatus(),
                 card.getCardCategory(),
                 card.getCarrier(),

--- a/src/main/java/com/ureca/snac/board/service/response/CreateCardResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/CreateCardResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.board.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateCardResponse {
+    private Long cardId;
+}

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
@@ -3,6 +3,7 @@ package com.ureca.snac.trade.controller;
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
+import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.dto.CancelTradeRequest;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.TradeFacade;
@@ -88,10 +89,11 @@ public class BasicTradeController implements BasicTradeControllerSwagger {
     @GetMapping("/scroll")
     public ResponseEntity<ApiResponse<ScrollTradeResponse>> scrollTrades(@RequestParam TradeSide side,
                                                                          @RequestParam(defaultValue = "10") int size,
+                                                                         @RequestParam(required = false) TradeQueryType tradeQueryType,
                                                                          @RequestParam(required = false, name = "cursorId") Long cursorId,
                                                                          @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok(ApiResponse.of(TRADE_SCROLL_SUCCESS,
-                tradeFacade.scrollTrades(userDetails.getUsername(), side, size, cursorId)));
+                tradeFacade.scrollTrades(userDetails.getUsername(), side, size, tradeQueryType, cursorId)));
     }
 
     @GetMapping("/{tradeId}")

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeControllerSwagger.java
@@ -6,9 +6,11 @@ import com.ureca.snac.swagger.annotation.response.ApiCreatedResponse;
 import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
 import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
+import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
 import com.ureca.snac.trade.service.response.ScrollTradeResponse;
+import com.ureca.snac.trade.service.response.TradeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -82,6 +84,7 @@ public interface BasicTradeControllerSwagger {
     @GetMapping("/scroll")
     ResponseEntity<ApiResponse<ScrollTradeResponse>> scrollTrades(@RequestParam TradeSide side,
                                                                   @RequestParam(defaultValue = "10") int size,
+                                                                  @RequestParam(required = false) TradeQueryType tradeQueryType,
                                                                   @RequestParam(required = false, name = "cursorId") Long cursorId,
                                                                   @AuthenticationPrincipal UserDetails userDetails);
 
@@ -93,4 +96,16 @@ public interface BasicTradeControllerSwagger {
     @PostMapping("/buy/accept")
     ResponseEntity<ApiResponse<?>> acceptBuyRequest(@RequestBody ClaimBuyRequest claimBuyRequest,
                                                     @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(
+            summary     = "단건 거래 조회",
+            description = "tradeId를 기반으로 단일 거래 정보를 조회합니다."
+    )
+    @ApiSuccessResponse(description = "거래 조회 성공")
+    @ErrorCode400(description = "잘못된 요청 파라미터")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @ErrorCode404(description = "거래를 찾을 수 없습니다")
+    @GetMapping("/{tradeId}")
+    ResponseEntity<ApiResponse<TradeResponse>> retrieveTrade(@PathVariable("tradeId") Long tradeId,
+                                                             @AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/com/ureca/snac/trade/controller/request/TradeQueryType.java
+++ b/src/main/java/com/ureca/snac/trade/controller/request/TradeQueryType.java
@@ -1,0 +1,5 @@
+package com.ureca.snac.trade.controller.request;
+
+public enum TradeQueryType {
+    OPEN, CLOSED
+}

--- a/src/main/java/com/ureca/snac/trade/repository/CustomTradeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/CustomTradeRepository.java
@@ -1,10 +1,11 @@
 package com.ureca.snac.trade.repository;
 
+import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.entity.Trade;
 
 import java.util.List;
 
 public interface CustomTradeRepository {
-    List<Trade> findTradesByBuyerInfinite(Long buyerId, Long lastTradeId, int limit);
-    List<Trade> findTradesBySellerInfinite(Long sellerId,  Long lastTradeId, int limit);
+    List<Trade> findTradesByBuyerInfinite(Long buyerId, Long lastTradeId, TradeQueryType tradeQueryType,  int limit);
+    List<Trade> findTradesBySellerInfinite(Long sellerId,  Long lastTradeId, TradeQueryType tradeQueryType, int limit);
 }

--- a/src/main/java/com/ureca/snac/trade/repository/TradeRepositoryImpl.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.ureca.snac.trade.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,11 +19,33 @@ public class TradeRepositoryImpl implements CustomTradeRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public List<Trade> findTradesByBuyerInfinite(Long buyerId, Long lastTradeId, int limit) {
+    public List<Trade> findTradesByBuyerInfinite(Long buyerId, Long lastTradeId, TradeQueryType tradeQueryType, int limit) {
         BooleanExpression predicate = trade.buyer.id.eq(buyerId);
 
         if (lastTradeId != null) {
             predicate = predicate.and(trade.id.lt(lastTradeId));
+        }
+
+        // 거래중 인 거래
+        if (tradeQueryType == TradeQueryType.OPEN) {
+            predicate = predicate.and(
+                    trade.status.notIn(
+                            TradeStatus.CANCELED,
+                            TradeStatus.COMPLETED,
+                            TradeStatus.AUTO_REFUND,
+                            TradeStatus.AUTO_PAYOUT
+                    )
+            );
+        }
+        if (tradeQueryType == TradeQueryType.CLOSED) {
+            predicate = predicate.and(
+                    trade.status.in(
+                            TradeStatus.CANCELED,
+                            TradeStatus.COMPLETED,
+                            TradeStatus.AUTO_REFUND,
+                            TradeStatus.AUTO_PAYOUT
+                    )
+            );
         }
 
         return query.selectFrom(trade)
@@ -32,12 +56,35 @@ public class TradeRepositoryImpl implements CustomTradeRepository {
     }
 
     @Override
-    public List<Trade> findTradesBySellerInfinite(Long sellerId, Long lastTradeId, int limit) {
+    public List<Trade> findTradesBySellerInfinite(Long sellerId, Long lastTradeId, TradeQueryType tradeQueryType, int limit) {
         BooleanExpression predicate = trade.seller.id.eq(sellerId);
 
         if (lastTradeId != null) {
             predicate = predicate.and(trade.id.lt(lastTradeId));
         }
+
+        // 거래중 인 거래
+        if (tradeQueryType == TradeQueryType.OPEN) {
+            predicate = predicate.and(
+                    trade.status.notIn(
+                            TradeStatus.CANCELED,
+                            TradeStatus.COMPLETED,
+                            TradeStatus.AUTO_REFUND,
+                            TradeStatus.AUTO_PAYOUT
+                    )
+            );
+        }
+        if (tradeQueryType == TradeQueryType.CLOSED) {
+            predicate = predicate.and(
+                    trade.status.in(
+                            TradeStatus.CANCELED,
+                            TradeStatus.COMPLETED,
+                            TradeStatus.AUTO_REFUND,
+                            TradeStatus.AUTO_PAYOUT
+                    )
+            );
+        }
+
         return query
                 .selectFrom(trade)
                 .where(predicate)

--- a/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
@@ -47,12 +47,13 @@ public class TradeCancelServiceImpl implements TradeCancelService {
     @Override
     public void requestCancel(Long tradeId, String userEmail, CancelReason reason) {
 
+        Member requester = tradeSupport.findMember(userEmail);
+
         Trade trade = tradeSupport.findLockedTrade(tradeId);
 
         // 제목 생성위해서 만들었음.. 리팩토링 시 변경 가능
         Card card = tradeSupport.findLockedCard(trade.getCardId());
 
-        Member requester = tradeSupport.findMember(userEmail);
         // 구매자 따로 뺏음
         Member buyer = trade.getBuyer();
 

--- a/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeFacade.java
@@ -4,6 +4,7 @@ import com.ureca.snac.board.service.CardService;
 import com.ureca.snac.config.RabbitMQConfig;
 import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
+import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.dto.TradeMessageDto;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.entity.CancelReason;
@@ -89,8 +90,8 @@ public class TradeFacade {
         return tradeQueryService.getTradeById(tradeId, username);
     }
 
-    public ScrollTradeResponse scrollTrades(String username, TradeSide side, int size, Long lastTradeId) {
-        return tradeQueryService.scrollTrades(username, side, size, lastTradeId);
+    public ScrollTradeResponse scrollTrades(String username, TradeSide side, int size, TradeQueryType tradeQueryType, Long lastTradeId) {
+        return tradeQueryService.scrollTrades(username, side, size, tradeQueryType, lastTradeId);
     }
 
     public ProgressTradeCountResponse countSellingProgress(String username) {

--- a/src/main/java/com/ureca/snac/trade/service/TradeInitiationServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeInitiationServiceImpl.java
@@ -51,7 +51,7 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
         Card card = tradeSupport.findLockedCard(trade.getCardId());
 
         // 카드는 판매 상태이여야 함
-        if (card.getSellStatus() == TRADING) {
+        if (card.getSellStatus() != SELLING) {
             throw new CardInvalidStatusException();
         }
 
@@ -75,10 +75,10 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
     @Transactional
     public Long payRealTimeTrade(CreateRealTimeTradePaymentRequest createRealTimeTradePaymentRequest, String username) {
         // 1. 거래 조회 (락 걸어서)
-        Trade trade = tradeSupport.findLockedTrade(createRealTimeTradePaymentRequest.getTradeId());
         Member member = tradeSupport.findMember(username);
-        Wallet wallet = tradeSupport.findLockedWallet(member.getId());
+        Trade trade = tradeSupport.findLockedTrade(createRealTimeTradePaymentRequest.getTradeId());
         Card card = tradeSupport.findLockedCard(trade.getCardId());
+        Wallet wallet = tradeSupport.findLockedWallet(member.getId());
 
         // 카드는 거래 상태이어야 함
         if (card.getSellStatus() != TRADING) {
@@ -172,11 +172,11 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
     @Override
     @Transactional
     public Long acceptBuyRequest(ClaimBuyRequest claimBuyRequest, String username) {
-        Card card = tradeSupport.findLockedCard(claimBuyRequest.getCardId());
         Member seller = tradeSupport.findMember(username);
         Trade trade = tradeRepository
                 .findLockedByCardId(claimBuyRequest.getCardId())
                 .orElseThrow(TradeNotFoundException::new);
+        Card card = tradeSupport.findLockedCard(claimBuyRequest.getCardId());
 
         // 판매 가능 상태가 아니라면 이미 거래 중으로 간주
         if (card.getSellStatus() != SELLING) {

--- a/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
@@ -39,8 +39,8 @@ public class TradeProgressServiceImpl implements TradeProgressService {
     @Override
     @Transactional
     public Long sendTradeData(Long tradeId, String username) {
-        Trade trade = tradeSupport.findLockedTrade(tradeId);
         Member seller = tradeSupport.findMember(username);
+        Trade trade = tradeSupport.findLockedTrade(tradeId);
         Card card = tradeSupport.findLockedCard(trade.getCardId());
 
         if (trade.getStatus() != PAYMENT_CONFIRMED) { // 결제가 완료되지 않은 상태에서는 판매자가 데이터를 전송할 수 없음

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/TradeQueryService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/TradeQueryService.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.service.interfaces;
 
+import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
@@ -18,7 +19,7 @@ public interface TradeQueryService {
      * @param lastTradeId 커서용 마지막 거래 ID
      * @return 거래 목록 및 다음 페이지 정보
      */
-    ScrollTradeResponse scrollTrades(String username, TradeSide side, int size, Long lastTradeId);
+    ScrollTradeResponse scrollTrades(String username, TradeSide side, int size, TradeQueryType tradeQueryType, Long lastTradeId);
 
     /**
      * 판매자 관점 진행 중 거래 수를 조회합니다.

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
@@ -5,6 +5,7 @@ import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.entity.CancelReason;
 import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.entity.TradeStatus;
+import com.ureca.snac.trade.entity.TradeType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +17,10 @@ import java.time.LocalDateTime;
 public class TradeResponse {
     private Long tradeId;
 
+    // 판매자 OR 구매자
+    private String buyer;
+    private String seller;
+
     private Integer priceGb;
     private Integer dataAmount;
     private String phone;
@@ -23,18 +28,35 @@ public class TradeResponse {
     private Carrier carrier;
     private CancelReason cancelReason;
     private TradeStatus status;
+    private TradeType tradeType;
 
     private LocalDateTime createdAt;
 
-    public static TradeResponse from(Trade trade) {
+    public static TradeResponse from(Trade trade, String username) {
+        String phoneToShow = null;
+
+        // 구매자 측면에서는 언제나 본인 번호를 보여주고,
+        if (username.equals(trade.getBuyer().getEmail())) {
+            phoneToShow = trade.getPhone();
+        }
+        // 판매자 측면에서는 결제 확정 단계(PAYMENT_CONFIRMED)일 때만 보여줌
+        else if (username.equals(trade.getSeller().getEmail()) && trade.getStatus() == TradeStatus.PAYMENT_CONFIRMED) {
+            phoneToShow = trade.getPhone();
+        }
+
         return new TradeResponse(
                 trade.getId(),
+
+                trade.getBuyer().getEmail(),
+                trade.getSeller().getEmail(),
+
                 trade.getPriceGb(),
                 trade.getDataAmount(),
-                null,
+                phoneToShow,
                 trade.getCarrier(),
                 trade.getCancelReason(),
                 trade.getStatus(),
+                trade.getTradeType(),
                 trade.getCreatedAt()
         );
     }
@@ -53,12 +75,15 @@ public class TradeResponse {
 
         return new TradeResponse(
                 trade.getId(),
+                trade.getBuyer().getEmail(),
+                trade.getSeller().getEmail(),
                 trade.getPriceGb(),
                 trade.getDataAmount(),
                 phoneToShow,
                 trade.getCarrier(),
                 trade.getCancelReason(),
                 trade.getStatus(),
+                trade.getTradeType(),
                 trade.getCreatedAt()
         );
     }


### PR DESCRIPTION
## 📝 변경 사항

1. 카드 생성 시 ID 반환
2. ID 기반 카드 조회 API 추가
3. username 기준 판매중인 카드 조회 API 추가
4. 데드락 방지를 위해 락 획득 순서 일관화

## 🔍 변경 사항 세부 설명

- 구매글의 경우 카드를 생성 후 바로 결제를 진행해야 하므로 카드 아이디가 필요하여 카드 생성 시 ID를 반환하도록 수정했습니다.
- ID 기반 카드 조회 또한 결제 페이지에서 카드 정보가 필요하기 때문에 추가했습니다.
- 단골 페이지에서 단골이 등록한 카드를 확인하기 위해 username 기반 카드 조회 API를 추가했습니다.
- 데드락 방지를 위해 락 획득 순서를 일관화 했습니다.

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 