### PR TITLE
Qi1 117 게시글 생성 조회 수정 삭제 api 개발

### DIFF
--- a/src/main/java/com/ureca/snac/asset/entity/TransactionCategory.java
+++ b/src/main/java/com/ureca/snac/asset/entity/TransactionCategory.java
@@ -28,7 +28,7 @@ public enum TransactionCategory {
     public boolean isValidFor(AssetType assetType) {
         return switch (assetType) {
             case MONEY -> this == RECHARGE || this == CANCEL || this == BUY || this == SELL;
-            case POINT -> this == EVENT || this == POINT_USAGE;
+            case POINT -> this == EVENT || this == POINT_USAGE || this == CANCEL;
         };
     }
 
@@ -38,7 +38,7 @@ public enum TransactionCategory {
      */
     public boolean isConsistentWith(TransactionType transactionType) {
         return switch (transactionType) {
-            case DEPOSIT -> this == RECHARGE || this == SELL || this == EVENT;
+            case DEPOSIT -> this == RECHARGE || this == SELL || this == EVENT || this == CANCEL;
             case WITHDRAWAL -> this == BUY || this == CANCEL || this == POINT_USAGE;
         };
     }

--- a/src/main/java/com/ureca/snac/board/controller/ArticleController.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleController.java
@@ -1,9 +1,12 @@
 package com.ureca.snac.board.controller;
 
 import com.ureca.snac.board.controller.request.CreateArticleRequest;
+import com.ureca.snac.board.controller.request.UpdateArticleRequest;
 import com.ureca.snac.board.service.ArticleService;
 import com.ureca.snac.board.service.response.CreateArticleResponse;
+import com.ureca.snac.board.service.response.UpdateArticleResponse;
 import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.common.BaseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -32,4 +35,16 @@ public class ArticleController implements ArticleControllerSwagger {
         return ResponseEntity.status(ARTICLE_CREATE_SUCCESS.getStatus())
                 .body(ApiResponse.of(ARTICLE_CREATE_SUCCESS, new CreateArticleResponse(articleId)));
     }
+
+    @PutMapping(value = "/{articleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<?>> editArticle(@PathVariable("articleId") Long articleId,
+                                                      @ModelAttribute UpdateArticleRequest updateArticleRequest,
+                                                      @RequestPart MultipartFile file,
+                                                      @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long updateArticleId = articleService.updateArticle(articleId, updateArticleRequest, file, userDetails.getUsername());
+
+        return ResponseEntity.ok(ApiResponse.of(ARTICLE_UPDATE_SUCCESS, new UpdateArticleResponse(updateArticleId)));
+    }
+
 }

--- a/src/main/java/com/ureca/snac/board/controller/ArticleController.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleController.java
@@ -37,7 +37,7 @@ public class ArticleController implements ArticleControllerSwagger {
     }
 
     @PutMapping(value = "/{articleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<?>> editArticle(@PathVariable("articleId") Long articleId,
+    public ResponseEntity<ApiResponse<UpdateArticleResponse>> editArticle(@PathVariable("articleId") Long articleId,
                                                       @RequestParam String title,
                                                       @RequestPart MultipartFile file,
                                                       @RequestPart MultipartFile image,

--- a/src/main/java/com/ureca/snac/board/controller/ArticleController.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleController.java
@@ -1,12 +1,11 @@
 package com.ureca.snac.board.controller;
 
-import com.ureca.snac.board.controller.request.CreateArticleRequest;
-import com.ureca.snac.board.controller.request.UpdateArticleRequest;
 import com.ureca.snac.board.service.ArticleService;
+import com.ureca.snac.board.service.response.ArticleResponse;
 import com.ureca.snac.board.service.response.CreateArticleResponse;
+import com.ureca.snac.board.service.response.ListArticleResponse;
 import com.ureca.snac.board.service.response.UpdateArticleResponse;
 import com.ureca.snac.common.ApiResponse;
-import com.ureca.snac.common.BaseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -27,10 +26,11 @@ public class ArticleController implements ArticleControllerSwagger {
     private final ArticleService articleService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<CreateArticleResponse>> addArticle(@ModelAttribute CreateArticleRequest createArticleRequest,
+    public ResponseEntity<ApiResponse<CreateArticleResponse>> addArticle(@RequestParam String title,
                                                                          @RequestPart MultipartFile file,
+                                                                         @RequestPart MultipartFile image,
                                                                          @AuthenticationPrincipal UserDetails userDetails) {
-        Long articleId = articleService.createArticle(createArticleRequest, file, userDetails.getUsername());
+        Long articleId = articleService.createArticle(title, file, image, userDetails.getUsername());
 
         return ResponseEntity.status(ARTICLE_CREATE_SUCCESS.getStatus())
                 .body(ApiResponse.of(ARTICLE_CREATE_SUCCESS, new CreateArticleResponse(articleId)));
@@ -38,13 +38,15 @@ public class ArticleController implements ArticleControllerSwagger {
 
     @PutMapping(value = "/{articleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<?>> editArticle(@PathVariable("articleId") Long articleId,
-                                                      @ModelAttribute UpdateArticleRequest updateArticleRequest,
+                                                      @RequestParam String title,
                                                       @RequestPart MultipartFile file,
+                                                      @RequestPart MultipartFile image,
                                                       @AuthenticationPrincipal UserDetails userDetails) {
 
-        Long updateArticleId = articleService.updateArticle(articleId, updateArticleRequest, file, userDetails.getUsername());
+        Long updateArticleId = articleService.updateArticle(articleId, title, file, image, userDetails.getUsername());
 
-        return ResponseEntity.ok(ApiResponse.of(ARTICLE_UPDATE_SUCCESS, new UpdateArticleResponse(updateArticleId)));
+        return ResponseEntity
+                .ok(ApiResponse.of(ARTICLE_UPDATE_SUCCESS, new UpdateArticleResponse(updateArticleId)));
     }
 
     @DeleteMapping("/{articleId}")
@@ -52,7 +54,21 @@ public class ArticleController implements ArticleControllerSwagger {
                                                         @AuthenticationPrincipal UserDetails userDetails) {
         articleService.deleteArticle(articleId, userDetails.getUsername());
 
-        return ResponseEntity.ok(ApiResponse.ok(ARTICLE_DELETE_SUCCESS));
+        return ResponseEntity
+                .ok(ApiResponse.ok(ARTICLE_DELETE_SUCCESS));
     }
 
+    @GetMapping("/{articleId}")
+    public ResponseEntity<ApiResponse<ArticleResponse>> getArticle(@PathVariable("articleId") Long articleId) {
+        return ResponseEntity
+                .ok(ApiResponse.of(ARTICLE_READ_SUCCESS, articleService.getArticle(articleId)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ListArticleResponse>> getArticles(@RequestParam(required = false) Long lastArticleId,
+                                                                        @RequestParam(defaultValue = "9") Integer size){
+
+        return ResponseEntity
+                .ok(ApiResponse.of(ACCOUNT_LIST_SUCCESS, articleService.getArticles(lastArticleId, size)));
+    }
 }

--- a/src/main/java/com/ureca/snac/board/controller/ArticleController.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleController.java
@@ -47,4 +47,12 @@ public class ArticleController implements ArticleControllerSwagger {
         return ResponseEntity.ok(ApiResponse.of(ARTICLE_UPDATE_SUCCESS, new UpdateArticleResponse(updateArticleId)));
     }
 
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<ApiResponse<?>> removeArticle(@PathVariable("articleId") Long articleId,
+                                                        @AuthenticationPrincipal UserDetails userDetails) {
+        articleService.deleteArticle(articleId, userDetails.getUsername());
+
+        return ResponseEntity.ok(ApiResponse.ok(ARTICLE_DELETE_SUCCESS));
+    }
+
 }

--- a/src/main/java/com/ureca/snac/board/controller/ArticleController.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleController.java
@@ -1,0 +1,35 @@
+package com.ureca.snac.board.controller;
+
+import com.ureca.snac.board.controller.request.CreateArticleRequest;
+import com.ureca.snac.board.service.ArticleService;
+import com.ureca.snac.board.service.response.CreateArticleResponse;
+import com.ureca.snac.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.ureca.snac.common.BaseCode.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/articles")
+@RequiredArgsConstructor
+public class ArticleController implements ArticleControllerSwagger {
+
+    private final ArticleService articleService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<CreateArticleResponse>> addArticle(@ModelAttribute CreateArticleRequest createArticleRequest,
+                                                                         @RequestPart MultipartFile file,
+                                                                         @AuthenticationPrincipal UserDetails userDetails) {
+        Long articleId = articleService.createArticle(createArticleRequest, file, userDetails.getUsername());
+
+        return ResponseEntity.status(ARTICLE_CREATE_SUCCESS.getStatus())
+                .body(ApiResponse.of(ARTICLE_CREATE_SUCCESS, new CreateArticleResponse(articleId)));
+    }
+}

--- a/src/main/java/com/ureca/snac/board/controller/ArticleControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleControllerSwagger.java
@@ -1,7 +1,103 @@
 package com.ureca.snac.board.controller;
 
+import com.ureca.snac.board.service.response.ArticleResponse;
+import com.ureca.snac.board.service.response.CreateArticleResponse;
+import com.ureca.snac.board.service.response.ListArticleResponse;
+import com.ureca.snac.board.service.response.UpdateArticleResponse;
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.swagger.annotation.error.ErrorCode400;
+import com.ureca.snac.swagger.annotation.error.ErrorCode401;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiCreatedResponse;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "게시글 관리", description = "게시글 등록, 조회, 수정, 삭제, 목록(무한스크롤) 기능 제공")
 @SecurityRequirement(name = "Authorization")
 public interface ArticleControllerSwagger {
+
+    @Operation(
+            summary = "게시글 등록",
+            description = """
+                새로운 게시글을 등록합니다.
+                - 제목, 본문 파일, 이미지 파일을 모두 첨부해야 합니다.
+                - 파일은 multipart/form-data로 전송해야 합니다.
+            """
+    )
+    @ApiCreatedResponse(description = "등록 성공")
+    @ErrorCode400(description = "등록 실패 - 입력값이 잘못되었습니다.")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<ApiResponse<CreateArticleResponse>> addArticle(
+            @Parameter(description = "게시글 제목") @RequestParam String title,
+            @Parameter(description = "게시글 본문 파일(.md 등)") @RequestPart MultipartFile file,
+            @Parameter(description = "게시글 대표 이미지 파일") @RequestPart MultipartFile image,
+            @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(
+            summary = "게시글 수정",
+            description = """
+                기존 게시글의 정보를 수정합니다.
+                - 제목, 본문 파일, 이미지 파일을 모두 새로 첨부해야 합니다.
+                - 기존 파일은 삭제 후 새 파일로 교체됩니다.
+            """
+    )
+    @ApiSuccessResponse(description = "수정 성공")
+    @ErrorCode400(description = "수정 실패 - 입력값이 잘못되었습니다.")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @ErrorCode404(description = "존재하지 않는 게시글 ID")
+    @PutMapping(value = "/{articleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<ApiResponse<UpdateArticleResponse>> editArticle(
+            @Parameter(description = "수정할 게시글 ID") @PathVariable("articleId") Long articleId,
+            @Parameter(description = "게시글 제목") @RequestParam String title,
+            @Parameter(description = "게시글 본문 파일(.md 등)") @RequestPart MultipartFile file,
+            @Parameter(description = "게시글 대표 이미지 파일") @RequestPart MultipartFile image,
+            @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(
+            summary = "게시글 삭제",
+            description = "등록된 게시글을 삭제합니다."
+    )
+    @ApiSuccessResponse(description = "삭제 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @ErrorCode404(description = "삭제 실패 - 존재하지 않는 게시글 ID")
+    @DeleteMapping("/{articleId}")
+    ResponseEntity<ApiResponse<?>> removeArticle(@Parameter(description = "삭제할 게시글 ID") @PathVariable("articleId") Long articleId,
+                                                 @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(
+            summary = "게시글 상세 조회",
+            description = "게시글 ID를 통해 등록된 게시글의 상세 정보를 조회합니다."
+    )
+    @ApiSuccessResponse(description = "게시글 상세 정보 조회 성공")
+    @ErrorCode404(description = "조회 실패 - 존재하지 않는 게시글 ID")
+    @GetMapping("/{articleId}")
+    ResponseEntity<ApiResponse<ArticleResponse>> getArticle(
+            @Parameter(description = "게시글 ID") @PathVariable("articleId") Long articleId);
+
+    @Operation(
+            summary = "게시글 목록 조회 (무한 스크롤)",
+            description = """
+                게시글을 커서 방식(무한 스크롤)으로 조회합니다.
+                - lastArticleId: 마지막으로 조회한 게시글 ID(커서, 생략 시 최신부터)
+                - size: 한 번에 조회할 개수(기본값 9)
+                - hasNext: 추가 데이터 존재 여부 반환
+            """
+    )
+    @ApiSuccessResponse(description = "목록 조회 성공")
+    @ErrorCode400(description = "조회 실패 - 잘못된 요청 파라미터")
+    @GetMapping
+    ResponseEntity<ApiResponse<ListArticleResponse>> getArticles(
+            @Parameter(description = "마지막으로 조회한 게시글 ID(커서)") @RequestParam(required = false) Long lastArticleId,
+            @Parameter(description = "페이지 당 조회 개수", example = "9") @RequestParam(defaultValue = "9") Integer size
+    );
 }

--- a/src/main/java/com/ureca/snac/board/controller/ArticleControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleControllerSwagger.java
@@ -1,0 +1,7 @@
+package com.ureca.snac.board.controller;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+@SecurityRequirement(name = "Authorization")
+public interface ArticleControllerSwagger {
+}

--- a/src/main/java/com/ureca/snac/board/controller/request/CreateArticleRequest.java
+++ b/src/main/java/com/ureca/snac/board/controller/request/CreateArticleRequest.java
@@ -1,0 +1,9 @@
+package com.ureca.snac.board.controller.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class CreateArticleRequest {
+    private String title;
+}

--- a/src/main/java/com/ureca/snac/board/controller/request/UpdateArticleRequest.java
+++ b/src/main/java/com/ureca/snac/board/controller/request/UpdateArticleRequest.java
@@ -1,4 +1,9 @@
 package com.ureca.snac.board.controller.request;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
 public class UpdateArticleRequest {
+    private String title;
 }

--- a/src/main/java/com/ureca/snac/board/controller/request/UpdateArticleRequest.java
+++ b/src/main/java/com/ureca/snac/board/controller/request/UpdateArticleRequest.java
@@ -1,0 +1,4 @@
+package com.ureca.snac.board.controller.request;
+
+public class UpdateArticleRequest {
+}

--- a/src/main/java/com/ureca/snac/board/entity/Article.java
+++ b/src/main/java/com/ureca/snac/board/entity/Article.java
@@ -1,0 +1,42 @@
+package com.ureca.snac.board.entity;
+
+import com.ureca.snac.common.BaseTimeEntity;
+import com.ureca.snac.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "artice_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "article_url", nullable = false)
+    private String articleUrl;
+
+    @Column(name = "title")
+    private String title;
+
+    @Builder
+    private Article(Member member, String articleUrl, String title) {
+        this.member = member;
+        this.articleUrl = articleUrl;
+        this.title = title;
+    }
+
+    public void update(String articleUrl, String title) {
+        this.articleUrl = articleUrl;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/ureca/snac/board/entity/Article.java
+++ b/src/main/java/com/ureca/snac/board/entity/Article.java
@@ -25,18 +25,23 @@ public class Article extends BaseTimeEntity {
     @Column(name = "article_url", nullable = false)
     private String articleUrl;
 
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
     @Column(name = "title")
     private String title;
 
     @Builder
-    private Article(Member member, String articleUrl, String title) {
+    private Article(Member member, String articleUrl, String imageUrl, String title) {
         this.member = member;
         this.articleUrl = articleUrl;
+        this.imageUrl = imageUrl;
         this.title = title;
     }
 
-    public void update(String articleUrl, String title) {
+    public void update(String articleUrl, String imageUrl, String title) {
         this.articleUrl = articleUrl;
+        this.imageUrl = imageUrl;
         this.title = title;
     }
 }

--- a/src/main/java/com/ureca/snac/board/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/ureca/snac/board/exception/ArticleNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.board.exception;
+
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.common.exception.BusinessException;
+
+public class ArticleNotFoundException extends BusinessException {
+    public ArticleNotFoundException() {
+        super(BaseCode.ARTICLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.snac.board.repository;
+
+import com.ureca.snac.board.entity.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
@@ -1,7 +1,12 @@
 package com.ureca.snac.board.repository;
 
 import com.ureca.snac.board.entity.Article;
+import com.ureca.snac.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    Optional<Article> findByMemberAndId(Member member, Long articleId);
 }

--- a/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends JpaRepository<Article, Long>, ArticleRepositoryCustom {
 
     Optional<Article> findByMemberAndId(Member member, Long articleId);
 }

--- a/src/main/java/com/ureca/snac/board/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/ureca/snac/board/repository/ArticleRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.ureca.snac.board.repository;
+
+import com.ureca.snac.board.entity.Article;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<Article> findArticlesByCursor(Long lastArticleId, Integer size);
+}

--- a/src/main/java/com/ureca/snac/board/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/ureca/snac/board/repository/ArticleRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.ureca.snac.board.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.snac.board.entity.Article;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ureca.snac.board.entity.QArticle.article;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Article> findArticlesByCursor(Long lastArticleId, Integer size) {
+        return query
+                .selectFrom(article)
+                .where(lastArticleId != null ? article.id.lt(lastArticleId) : null)
+                .orderBy(article.id.desc())
+                .limit(size)
+                .fetch();
+    }
+}

--- a/src/main/java/com/ureca/snac/board/service/ArticleService.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleService.java
@@ -1,20 +1,17 @@
 package com.ureca.snac.board.service;
 
-import com.ureca.snac.board.controller.request.CreateArticleRequest;
-import com.ureca.snac.board.controller.request.UpdateArticleRequest;
 import com.ureca.snac.board.service.response.ArticleResponse;
+import com.ureca.snac.board.service.response.ListArticleResponse;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 public interface ArticleService {
-    Long createArticle(CreateArticleRequest request, MultipartFile file, String username);
+    Long createArticle(String title, MultipartFile file, MultipartFile image, String username);
 
     ArticleResponse getArticle(Long articleId);
 
-    List<ArticleResponse> getArticles();
+    ListArticleResponse getArticles(Long lastArticleId, Integer size);
 
-    Long updateArticle(Long articleId, UpdateArticleRequest request, MultipartFile file, String username);
+    Long updateArticle(Long articleId, String title, MultipartFile file, MultipartFile image, String username);
 
     void deleteArticle(Long articleId, String username);
 }

--- a/src/main/java/com/ureca/snac/board/service/ArticleService.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleService.java
@@ -1,0 +1,20 @@
+package com.ureca.snac.board.service;
+
+import com.ureca.snac.board.controller.request.CreateArticleRequest;
+import com.ureca.snac.board.controller.request.UpdateArticleRequest;
+import com.ureca.snac.board.service.response.ArticleResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ArticleService {
+    Long createArticle(CreateArticleRequest request, MultipartFile file, String username);
+
+    ArticleResponse getArticle(Long articleId);
+
+    List<ArticleResponse> getArticles();
+
+    ArticleResponse updateArticle(Long articleId, UpdateArticleRequest request, String username);
+
+    void deleteArticle(Long articleId, String username);
+}

--- a/src/main/java/com/ureca/snac/board/service/ArticleService.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleService.java
@@ -14,7 +14,7 @@ public interface ArticleService {
 
     List<ArticleResponse> getArticles();
 
-    ArticleResponse updateArticle(Long articleId, UpdateArticleRequest request, String username);
+    Long updateArticle(Long articleId, UpdateArticleRequest request, MultipartFile file, String username);
 
     void deleteArticle(Long articleId, String username);
 }

--- a/src/main/java/com/ureca/snac/board/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleServiceImpl.java
@@ -60,6 +60,7 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
+    @Transactional
     public Long updateArticle(Long articleId, UpdateArticleRequest request, MultipartFile file, String username) {
         Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
 
@@ -74,7 +75,12 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
+    @Transactional
     public void deleteArticle(Long articleId, String username) {
+        Member member = memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
+        Article article = articleRepository.findByMemberAndId(member, articleId).orElseThrow(ArticleNotFoundException::new);
+        s3Uploader.delete(article.getArticleUrl());
 
+        articleRepository.delete(article);
     }
 }

--- a/src/main/java/com/ureca/snac/board/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleServiceImpl.java
@@ -1,0 +1,70 @@
+package com.ureca.snac.board.service;
+
+import com.ureca.snac.board.controller.request.CreateArticleRequest;
+import com.ureca.snac.board.controller.request.UpdateArticleRequest;
+import com.ureca.snac.board.entity.Article;
+import com.ureca.snac.board.repository.ArticleRepository;
+import com.ureca.snac.board.service.response.ArticleResponse;
+import com.ureca.snac.common.s3.S3Path;
+import com.ureca.snac.common.s3.S3Uploader;
+import com.ureca.snac.member.Member;
+import com.ureca.snac.member.MemberRepository;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArticleServiceImpl implements ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+    private final S3Uploader s3Uploader;
+
+    @Override
+    @Transactional
+    public Long createArticle(CreateArticleRequest request, MultipartFile file, String username) {
+        String s3Key = s3Uploader.upload(file, S3Path.ARTICLE_CONTENT);
+
+        Member member = memberRepository
+                .findByEmail(username)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Article article = Article.builder()
+                .member(member)
+                .title(request.getTitle())
+                .articleUrl(s3Key)
+                .build();
+
+        Article savedArticle = articleRepository.save(article);
+
+        return savedArticle.getId();
+    }
+
+    @Override
+    public ArticleResponse getArticle(Long articleId) {
+        return null;
+    }
+
+    @Override
+    public List<ArticleResponse> getArticles() {
+        return List.of();
+    }
+
+    @Override
+    public ArticleResponse updateArticle(Long articleId, UpdateArticleRequest request, String username) {
+        return null;
+    }
+
+    @Override
+    public void deleteArticle(Long articleId, String username) {
+
+    }
+}

--- a/src/main/java/com/ureca/snac/board/service/response/ArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/ArticleResponse.java
@@ -1,4 +1,30 @@
 package com.ureca.snac.board.service.response;
 
+import com.ureca.snac.board.entity.Article;
+import lombok.*;
+
+@Builder
+@Getter @Setter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ArticleResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String nickname;
+    private String articleUrl;
+    private String imageUrl;
+    private String title;
+
+    public static ArticleResponse from(Article article, String generateArticleKey, String generateImageKey) {
+        return ArticleResponse.builder()
+                .id(article.getId())
+                .email(article.getMember().getEmail())
+                .name(article.getMember().getName())
+                .nickname(article.getMember().getNickname())
+                .articleUrl(generateArticleKey)
+                .imageUrl(generateImageKey)
+                .build();
+    }
+
 }

--- a/src/main/java/com/ureca/snac/board/service/response/ArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/ArticleResponse.java
@@ -1,0 +1,4 @@
+package com.ureca.snac.board.service.response;
+
+public class ArticleResponse {
+}

--- a/src/main/java/com/ureca/snac/board/service/response/CreateArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/CreateArticleResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.board.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateArticleResponse {
+    private Long articleId;
+}

--- a/src/main/java/com/ureca/snac/board/service/response/ListArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/ListArticleResponse.java
@@ -1,0 +1,13 @@
+package com.ureca.snac.board.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ListArticleResponse {
+    private List<ArticleResponse> articleResponseList;
+    private Boolean hasNext;
+}

--- a/src/main/java/com/ureca/snac/board/service/response/UpdateArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/UpdateArticleResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.board.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateArticleResponse {
+    private Long articleId;
+}

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -278,6 +278,7 @@ public enum BaseCode {
 
     // S3
     S3_UPLOAD_FAILED("S3_UPLOAD_FAILED_500", HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드에 실패했습니다."),
+    S3_DELETE_FAILED("S3_DELETE_FAILED_500", HttpStatus.INTERNAL_SERVER_ERROR, "S3 삭제에 실패했습니다"),
     ATTACHMENT_UPLOAD_SUCCESS("ATTACHMENT_UPLOAD_SUCCESS_201", HttpStatus.CREATED, "이미지가 성공적으로 업로드되었습니다."),
     ATTACHMENT_PRESIGNED_URL_ISSUED("ATTACHMENT_PRESIGNED_URL_ISSUED_200", HttpStatus.OK, "첨부 이미지에 대한 접근 URL이 발급되었습니다.");
     private final String code;

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -105,6 +105,17 @@ public enum BaseCode {
     // 닉네임 변경 시간 검증 - 실패
     NICKNAME_CHANGE_TOO_EARLY("NICKNAME_CHANGE_TOO_EARLY_400", HttpStatus.BAD_REQUEST, "닉네임은 최근 변경 시점 24시간이 지난 후 수정할 수 있습니다."),
 
+    // 게시글 - 성공
+    ARTICLE_CREATE_SUCCESS("ARTICLE_CREATE_SUCCESS_201", HttpStatus.CREATED, "게시글이 성공적으로 등록되었습니다."),
+    ARTICLE_READ_SUCCESS("ARTICLE_READ_SUCCESS_200", HttpStatus.OK, "게시글을 성공적으로 조회했습니다."),
+    ARTICLE_LIST_SUCCESS("ARTICLE_LIST_SUCCESS_200", HttpStatus.OK, "게시글 목록을 성공적으로 조회했습니다."),
+    ARTICLE_UPDATE_SUCCESS("ARTICLE_UPDATE_SUCCESS_200", HttpStatus.OK, "게시글이 성공적으로 수정되었습니다."),
+    ARTICLE_DELETE_SUCCESS("ARTICLE_DELETE_SUCCESS_200", HttpStatus.OK, "게시글이 성공적으로 삭제되었습니다."),
+
+    // 게시글 - 실패
+    ARTICLE_NOT_FOUND("ARTICLE_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    ARTICLE_PERMISSION_DENIED("ARTICLE_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "해당 게시글에 대한 권한이 없습니다."),
+
     // 은행 - 성공
     BANK_CREATE_SUCCESS("BANK_CREATE_SUCCESS_201", HttpStatus.CREATED, "은행이 성공적으로 생성되었습니다."),
     BANK_READ_SUCCESS("BANK_READ_SUCCESS_200", HttpStatus.OK, "은행 정보를 성공적으로 조회했습니다."),

--- a/src/main/java/com/ureca/snac/common/s3/S3Path.java
+++ b/src/main/java/com/ureca/snac/common/s3/S3Path.java
@@ -6,5 +6,5 @@ package com.ureca.snac.common.s3;
 public class S3Path {
     public static final String TRADE_ATTACHMENT = "trade/attachments"; // 거래 첨부 이미지
     public static final String USER_PROFILE = "users/profile"; // 예) 프로필 이미지
-    public static final String BOARD_IMAGE = "boards/images"; // 예) 게시판 이미지
+    public static final String ARTICLE_CONTENT = "article/content"; // 예) 게시판 이미지
 }

--- a/src/main/java/com/ureca/snac/common/s3/S3Uploader.java
+++ b/src/main/java/com/ureca/snac/common/s3/S3Uploader.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -76,5 +77,20 @@ public class S3Uploader {
                 .build();
 
         return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+    // S3에서 파일 삭제
+    public void delete(String s3Key) {
+        try {
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(props.getBucket())
+                    .key(s3Key)
+                    .build();
+
+            s3Client.deleteObject(deleteRequest);
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패: {}", s3Key, e);
+            throw new BusinessException(BaseCode.S3_DELETE_FAILED);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application:
     name: snac-server
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 30MB
+
   security:
     oauth2:
       client:


### PR DESCRIPTION
## 📝 변경 사항

1. 파일업로드 크기 변경
2. 게시글 업로드, 수정, 삭제, 조회 기능 구현
3. 실시간 거래 기록 추가 및 거래 취소 시 거래 내역이 반영되지 않는 문제 해결

## 🔍 변경 사항 세부 설명

- 파일 업로드 크기를 기존 디폴트 1MB에서 10MB, 30MB로 변경했습니다.
- 게시글 : 대표 이미지 파일, 내용, 제목을 업로드, 수정이 가능합니다.
- 게시글 : 게시글 삭제시 기존 업로드한 파일 또한 삭제됩니다.
- 거래 기록 : 누락한 거래 기록 부분을 추가했습니다. 또한 취소시 거래 내역에 반영되지 않는 문제를 해결 했습니다.

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 