### PR TITLE
[fix]가격 범위 표현 수정

### DIFF
--- a/src/main/java/com/ureca/snac/board/controller/CardController.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardController.java
@@ -57,14 +57,14 @@ public class CardController implements CardControllerSwagger{
     @GetMapping("/scroll")
     public ResponseEntity<ApiResponse<ScrollCardResponse>> scrollCards(@RequestParam CardCategory cardCategory,
                                                                        @RequestParam(required = false) Carrier carrier,
-                                                                       @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
+                                                                       @RequestParam(value = "priceRanges") PriceRange priceRange,
                                                                        @RequestParam SellStatusFilter sellStatusFilter,
                                                                        @RequestParam(defaultValue = "true") Boolean highRatingFirst,
                                                                        @RequestParam(defaultValue = "54") Integer size,
                                                                        @RequestParam(required = false) Long lastCardId,
                                                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastUpdatedAt) {
 
-        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRanges,
+        ScrollCardResponse response = cardService.scrollCards(cardCategory, carrier, priceRange,
                 sellStatusFilter, highRatingFirst, size, lastCardId, lastUpdatedAt);
 
         return ResponseEntity.ok(ApiResponse.of(CARD_READ_SUCCESS, response));

--- a/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/CardControllerSwagger.java
@@ -83,7 +83,7 @@ public interface CardControllerSwagger {
                                                                         description = "카드 카테고리",
                                                                         schema = @Schema(type = "string", allowableValues = {"BUY", "SELL"}))@RequestParam CardCategory cardCategory,
                                                                 @RequestParam(required = false) Carrier carrier,
-                                                                @RequestParam(value = "priceRanges") List<PriceRange> priceRanges,
+                                                                @RequestParam(value = "priceRanges") PriceRange priceRange,
                                                                 @RequestParam SellStatusFilter sellStatusFilter,
                                                                 @RequestParam(defaultValue = "true") Boolean highRatingFirst,
                                                                 @RequestParam(defaultValue = "54") Integer size,

--- a/src/main/java/com/ureca/snac/board/entity/constants/PriceRange.java
+++ b/src/main/java/com/ureca/snac/board/entity/constants/PriceRange.java
@@ -7,13 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PriceRange {
 
-    ALL        (null,   null),
-    P0_999     (0,      999),
-    P1000_1499 (1000,   1499),
-    P1500_1999 (1500,   1999),
-    P2000_2499 (2000,   2499),
-    P2500_PLUS (2500,   null);
+    ALL     (null),
+    P0_1000 (1000),
+    P0_1500 (1500),
+    P0_2000 (2000),
+    P0_2500 (2500);
 
-    private final Integer min;
     private final Integer max;
 }

--- a/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
+++ b/src/main/java/com/ureca/snac/board/repository/CardRepositoryCustom.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface CardRepositoryCustom {
     List<Card> scroll(CardCategory cardCategory,
                       Carrier carrier,
-                      List<PriceRange> priceRanges,
+                      PriceRange priceRange,
                       SellStatusFilter sellStatusFilter,
                       Boolean highRatingFirst,
                       Integer size,

--- a/src/main/java/com/ureca/snac/board/service/CardService.java
+++ b/src/main/java/com/ureca/snac/board/service/CardService.java
@@ -47,7 +47,7 @@ public interface CardService {
      * @param lastUpdatedAt 커서: 마지막으로 조회된 카드의 수정 시각 (선택)
      * @return 스크롤 방식으로 응답하는 카드 목록과 다음 페이지 존재 여부
      */
-    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRange, SellStatusFilter sellStatusFilter, Boolean highRatingFirst,
+    ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, PriceRange priceRange, SellStatusFilter sellStatusFilter, Boolean highRatingFirst,
                                    Integer size, Long lastCardId, LocalDateTime lastUpdatedAt);
 
     /**

--- a/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/CardServiceImpl.java
@@ -110,10 +110,10 @@ public class CardServiceImpl implements CardService {
     }
 
     @Override
-    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, List<PriceRange> priceRanges, SellStatusFilter sellStatusFilter, Boolean highRatingFirst,
+    public ScrollCardResponse scrollCards(CardCategory cardCategory, Carrier carrier, PriceRange priceRange, SellStatusFilter sellStatusFilter, Boolean highRatingFirst,
                                           Integer size, Long lastCardId, LocalDateTime lastUpdatedAt) {
 
-        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRanges, sellStatusFilter, highRatingFirst,
+        List<Card> raw = cardRepository.scroll(cardCategory, carrier, priceRange, sellStatusFilter, highRatingFirst,
                 size + 1, lastCardId, lastUpdatedAt);
 
         boolean hasNext = raw.size() > size;

--- a/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
@@ -230,9 +230,8 @@ public class MatchingServiceFacade {
     }
 
     private boolean isPriceInRange(Integer price, PriceRange priceRange) {
-        Integer min = priceRange.getMin();
         Integer max = priceRange.getMax();
-        if (min != null && price < min) return false;
-        return max == null || price <= max;
+        // 0원 이상만 허용, max가 null이면 전체 허용
+        return price >= 0 && (max == null || price <= max);
     }
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 가격 범위 표현을 기존 범위 형식(예: 0~999)에서 서술형 형식(예: 1000원 이하)으로 변경

## 🔍 변경 사항 세부 설명

- 사용자 인터페이스 또는 필터 등에서 노출되는 가격 범위를 보다 직관적으로 이해할 수 있도록, 숫자 범위 표기(0~999)를 설명형 문구(1000원 이하)로 변경하였습니다.

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 