### PR TITLE
[feat] 단골 여부 api

### DIFF
--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -166,6 +166,7 @@ public enum BaseCode {
     // 단골 - 성공
     FAVORITE_CREATE_SUCCESS("FAVORITE_CREATE_SUCCESS_201", HttpStatus.CREATED, "단골 등록에 성공했습니다."),
     FAVORITE_LIST_SUCCESS("FAVORITE_LIST_SUCCESS_200", HttpStatus.OK, "단골 목록 조회에 성공했습니다."),
+    FAVORITE_CHECK_SUCCESS("FAVORITE_CHECK_SUCCESS_200", HttpStatus.OK, "단골 여부 조회에 성공했습니다."),
     FAVORITE_DELETE_SUCCESS("FAVORITE_DELETE_SUCCESS_200", HttpStatus.OK, "단골 삭제에 성공했습니다."),
 
     // 단골 - 예외

--- a/src/main/java/com/ureca/snac/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/ureca/snac/favorite/controller/FavoriteController.java
@@ -3,6 +3,7 @@ package com.ureca.snac.favorite.controller;
 import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.CursorResult;
+import com.ureca.snac.favorite.dto.FavoriteCheckResponse;
 import com.ureca.snac.favorite.dto.FavoriteCreateRequest;
 import com.ureca.snac.favorite.dto.FavoriteMemberDto;
 import com.ureca.snac.favorite.service.FavoriteService;
@@ -60,5 +61,19 @@ public class FavoriteController implements FavoriteSwagger {
         favoriteService.deleteFavorite(currentUserEmail, toMemberId);
 
         return ResponseEntity.ok(ApiResponse.ok(FAVORITE_DELETE_SUCCESS));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<FavoriteCheckResponse>> checkFavoriteStatus(
+            @RequestParam Long toMemberId,
+            @UserInfo CustomUserDetails userDetails) {
+        String currentUserEmail = userDetails.getUsername();
+
+        boolean isFavorite =
+                favoriteService.checkFavoriteStatus(currentUserEmail, toMemberId);
+
+        FavoriteCheckResponse response = new FavoriteCheckResponse(isFavorite);
+
+        return ResponseEntity.ok(ApiResponse.of(FAVORITE_CHECK_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ureca/snac/favorite/controller/FavoriteSwagger.java
+++ b/src/main/java/com/ureca/snac/favorite/controller/FavoriteSwagger.java
@@ -3,6 +3,7 @@ package com.ureca.snac.favorite.controller;
 import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.CursorResult;
+import com.ureca.snac.favorite.dto.FavoriteCheckResponse;
 import com.ureca.snac.favorite.dto.FavoriteCreateRequest;
 import com.ureca.snac.favorite.dto.FavoriteMemberDto;
 import com.ureca.snac.swagger.annotation.UserInfo;
@@ -71,6 +72,15 @@ public interface FavoriteSwagger {
     @DeleteMapping("/{toMemberId}")
     ResponseEntity<ApiResponse<Void>> deleteFavorite(
             @PathVariable Long toMemberId,
+            @UserInfo CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "단골 여부",
+            description = "특정 사용자가 나의 단골인지 여부 확인")
+    @GetMapping("/check")
+    ResponseEntity<ApiResponse<FavoriteCheckResponse>> checkFavoriteStatus(
+            @Parameter(description = "확인할 대상의 회원 ID", required = true)
+            @RequestParam Long toMemberId,
             @UserInfo CustomUserDetails userDetails
     );
 }

--- a/src/main/java/com/ureca/snac/favorite/dto/FavoriteCheckResponse.java
+++ b/src/main/java/com/ureca/snac/favorite/dto/FavoriteCheckResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.favorite.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "단골 여부 확인 응답 DTO")
+public record FavoriteCheckResponse(
+        @Schema(description = "단골 여부")
+        boolean isFavorite
+) {
+}

--- a/src/main/java/com/ureca/snac/favorite/service/FavoriteService.java
+++ b/src/main/java/com/ureca/snac/favorite/service/FavoriteService.java
@@ -42,8 +42,6 @@ public interface FavoriteService {
      */
     void deleteFavorite(String fromUserEmail, Long toMemberId);
 
-
-
     /**
      * 내가 등록한 단골의 총 개수를 조회.
      *
@@ -51,4 +49,13 @@ public interface FavoriteService {
      * @return 등록된 단골 수
      */
     Long getFavoriteCount(String fromUserEmail);
+
+    /**
+     * 단골 등록했는지에 대한 여부
+     *
+     * @param fromUserEmail 검색할 주체 회원 이메일
+     * @param toMemberId    상대방 ID
+     * @return 단골 여부
+     */
+    boolean checkFavoriteStatus(String fromUserEmail, Long toMemberId);
 }

--- a/src/main/java/com/ureca/snac/favorite/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/ureca/snac/favorite/service/FavoriteServiceImpl.java
@@ -121,8 +121,21 @@ public class FavoriteServiceImpl implements FavoriteService {
     public Long getFavoriteCount(String fromUserEmail) {
         Member fromMember = findMemberByEmail(fromUserEmail);
         Long count = favoriteRepository.countByFromMember(fromMember);
-        log.info("[단골 수 조회] 회원ID: {}, count: {}", fromMember.getId(), count);
+        log.info("[단골 수 조회] 회원 ID: {}, count: {}", fromMember.getId(), count);
         return count;
+    }
+
+    @Override
+    public boolean checkFavoriteStatus(String fromUserEmail, Long toMemberId) {
+        Member fromMember = findMemberByEmail(fromUserEmail);
+        Member toMember = findMemberById(toMemberId);
+
+        boolean isFavorite = favoriteRepository.existsByFromMemberAndToMember(fromMember, toMember);
+
+        log.info("[단골 여부 확인] 요청자 : {}, 상대방 : {}, 여부 : {}",
+                fromUserEmail, toMemberId, isFavorite);
+
+        return isFavorite;
     }
 
     private Member findMemberById(Long memberId) {

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeController.java
@@ -5,6 +5,7 @@ import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
 import com.ureca.snac.trade.controller.request.TradeQueryType;
 import com.ureca.snac.trade.dto.CancelTradeRequest;
+import com.ureca.snac.trade.dto.TradeConfirmResponse;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.TradeFacade;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
@@ -79,11 +80,11 @@ public class BasicTradeController implements BasicTradeControllerSwagger {
     }
 
     @PatchMapping("/{tradeId}/confirm")
-    public ResponseEntity<ApiResponse<?>> confirmTrade(@PathVariable Long tradeId,
-                                                       @AuthenticationPrincipal UserDetails userDetails) {
-        tradeFacade.confirmTrade(tradeId, userDetails.getUsername());
+    public ResponseEntity<ApiResponse<TradeConfirmResponse>> confirmTrade(@PathVariable Long tradeId,
+                                                                          @AuthenticationPrincipal UserDetails userDetails) {
+        TradeConfirmResponse response = tradeFacade.confirmTrade(tradeId, userDetails.getUsername());
 
-        return ResponseEntity.ok(ApiResponse.ok(TRADE_CONFIRM_SUCCESS));
+        return ResponseEntity.ok(ApiResponse.of(TRADE_CONFIRM_SUCCESS, response));
     }
 
     @GetMapping("/scroll")

--- a/src/main/java/com/ureca/snac/trade/controller/BasicTradeControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/BasicTradeControllerSwagger.java
@@ -7,6 +7,7 @@ import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
 import com.ureca.snac.trade.controller.request.ClaimBuyRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
 import com.ureca.snac.trade.controller.request.TradeQueryType;
+import com.ureca.snac.trade.dto.TradeConfirmResponse;
 import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.service.response.ProgressTradeCountResponse;
 import com.ureca.snac.trade.service.response.ScrollTradeResponse;
@@ -74,8 +75,8 @@ public interface BasicTradeControllerSwagger {
     @ErrorCode403(description = "구매자만 거래를 확정할 수 있습니다.")
     @ErrorCode404(description = "거래를 찾을 수 없습니다.")
     @PatchMapping("/{tradeId}/confirm")
-    ResponseEntity<ApiResponse<?>> confirmTrade(@PathVariable Long tradeId,
-                                                @AuthenticationPrincipal UserDetails userDetails);
+    ResponseEntity<ApiResponse<TradeConfirmResponse>> confirmTrade(@PathVariable Long tradeId,
+                                                                   @AuthenticationPrincipal UserDetails userDetails);
 
     @Operation(summary = "거래 내역 조회 (무한 스크롤)", description = "로그인한 사용자의 거래 내역을 BUY/SELL 관점으로 무한 스크롤 방식으로 조회합니다.")
     @ApiSuccessResponse(description = "거래 내역 조회 성공")
@@ -98,7 +99,7 @@ public interface BasicTradeControllerSwagger {
                                                     @AuthenticationPrincipal UserDetails userDetails);
 
     @Operation(
-            summary     = "단건 거래 조회",
+            summary = "단건 거래 조회",
             description = "tradeId를 기반으로 단일 거래 정보를 조회합니다."
     )
     @ApiSuccessResponse(description = "거래 조회 성공")

--- a/src/main/java/com/ureca/snac/trade/dto/TradeConfirmResponse.java
+++ b/src/main/java/com/ureca/snac/trade/dto/TradeConfirmResponse.java
@@ -1,0 +1,19 @@
+package com.ureca.snac.trade.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "거래 확정 성공 응답 DTO for 단골 등록")
+public record TradeConfirmResponse(
+        @Schema(description = "거래 Id")
+        Long tradeId,
+
+        @Schema(description = "거래 상대방의 ID")
+        Long counterId,
+
+        @Schema(description = "상대방 닉네임")
+        String counterNickname,
+
+        @Schema(description = "여부")
+        boolean isFavorite
+) {
+}

--- a/src/main/java/com/ureca/snac/trade/dto/TradeDto.java
+++ b/src/main/java/com/ureca/snac/trade/dto/TradeDto.java
@@ -7,14 +7,22 @@ import com.ureca.snac.trade.entity.TradeStatus;
 import lombok.*;
 
 @Builder
-@Getter @Setter
+@Getter
+@Setter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TradeDto {
     private Long tradeId;
     private Long cardId;
-    private Integer sellerRatingScore;
+
+    private Long sellerId;
     private String seller;
+    private String sellerNickName;
+    private Integer sellerRatingScore;
+
+    private Long buyerId;
     private String buyer;
+    private String buyerNickname;
+
     private Carrier carrier;
     private Integer priceGb;
     private Integer dataAmount;
@@ -27,9 +35,16 @@ public class TradeDto {
         return TradeDto.builder()
                 .tradeId(trade.getId())
                 .cardId(trade.getCardId())
-                .sellerRatingScore(trade.getSeller().getRatingScore())
+
+                .sellerId(trade.getSeller().getId())
                 .seller(trade.getSeller().getEmail())
+                .sellerNickName(trade.getSeller().getNickname())
+                .sellerRatingScore(trade.getSeller().getRatingScore())
+
+                .buyerId(trade.getBuyer().getId())
                 .buyer(trade.getBuyer().getEmail())
+                .buyerNickname(trade.getBuyer().getNickname())
+                
                 .carrier(trade.getCarrier())
                 .priceGb(trade.getPriceGb())
                 .dataAmount(trade.getDataAmount())

--- a/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
+++ b/src/main/java/com/ureca/snac/trade/service/MatchingServiceFacade.java
@@ -163,12 +163,13 @@ public class MatchingServiceFacade {
     // 실시간 매칭 - 구매자가 거래를 확정 ( Status == COMPLETED, Card == SOLD_OUT )
     @Transactional
     public void confirmTrade(ConfirmTradeRequest request, String username) {
-        Long tradeId = tradeProgressService.confirmTrade(request.getTradeId(), username, false);
+//        Long tradeId = tradeProgressService.confirmTrade(request.getTradeId(), username, false);
+        TradeDto confrimTradeDto = tradeProgressService.confirmTrade(request.getTradeId(), username, false);
 
-        TradeDto tradeDto = tradeQueryService.findByTradeId(tradeId);
+//        TradeDto tradeDto = tradeQueryService.findByTradeId(tradeId);
 
         // 판매자에게 확정 정보 제공
-        notificationService.notify(tradeDto.getSeller(), tradeDto);
+        notificationService.notify(confrimTradeDto.getSeller(), confrimTradeDto);
     }
 
     /*-------------------------------------------- 실시간 거래 프로세스 -------------------------------------------- */

--- a/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
@@ -6,6 +6,7 @@ import com.ureca.snac.asset.service.AssetHistoryEventPublisher;
 import com.ureca.snac.board.entity.Card;
 import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.member.Member;
+import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.exception.TradeSendPermissionDeniedException;
 import com.ureca.snac.trade.exception.TradeStatusMismatchException;
@@ -61,7 +62,7 @@ public class TradeProgressServiceImpl implements TradeProgressService {
     // 일반 매칭 hasCard == true, 실시간 매칭 == false
     @Override
     @Transactional
-    public Long confirmTrade(Long tradeId, String username, Boolean hasCard) {
+    public TradeDto confirmTrade(Long tradeId, String username, Boolean hasCard) {
         Trade trade = tradeSupport.findLockedTrade(tradeId);
         Member buyer = tradeSupport.findMember(username);
 //        Wallet wallet = tradeSupport.findLockedWallet(trade.getSeller().getId());
@@ -90,7 +91,7 @@ public class TradeProgressServiceImpl implements TradeProgressService {
 
         assetHistoryEventPublisher.publish(event);
 
-        return trade.getId();
+        return TradeDto.from(trade);
     }
 
     // 선택받지 못한 트레이드 자동 취소

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/TradeProgressService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/TradeProgressService.java
@@ -1,6 +1,8 @@
 package com.ureca.snac.trade.service.interfaces;
 
 
+import com.ureca.snac.trade.dto.TradeDto;
+
 public interface TradeProgressService {
 
     /**
@@ -17,7 +19,8 @@ public interface TradeProgressService {
      * @param tradeId  거래 ID
      * @param username 요청 판매자 이메일
      */
-    Long confirmTrade(Long tradeId, String username, Boolean hasCard);
+//    Long confirmTrade(Long tradeId, String username, Boolean hasCard);
+    TradeDto confirmTrade(Long tradeId, String username, Boolean hasCard);
 
 //    List<TradeDto> cancelOtherTradesOfCard(Long cardId, Long acceptedTradeId);
 //


### PR DESCRIPTION
## 📝 변경 사항

1. 거래확정 API 기능 확장 (일반 거래와 실시간 둘다 적용)
2. 단골 여부 확인 API 추가

## 🔍 변경 사항 세부 설명

- 거래 확정 API 개선은 void 에서 가져오는 응답 객체가 없었는데 단골을 등록하기 위한
현재 단골 등록여부를 내려주는 응답 DTO 생성
- 불필요한 DB 재조회를 제거했음
- 단골 여부 확인 API를 통해 여부를 확인해서 
- /api/favorites/check API에 응답 DTO 결과를 보내서 단골등록 여부를 따질 수 있다.

## 🕵️‍♀️ 요청사항

- 이미 단골이다 라고 뜨거나 단골로 등록하겠냐는 팝업 정도 고려해보면 될듯

## 📷 스크린샷 (선택)

<img width="1207" height="799" alt="스크린샷 2025-07-28 오전 1 37 13" src="https://github.com/user-attachments/assets/265bf4bf-42ab-41f1-854e-a52a98e3cd63" />
<img width="1224" height="285" alt="스크린샷 2025-07-28 오전 1 42 57" src="https://github.com/user-attachments/assets/554acea8-48e3-4ae5-9eed-7f80aed30748" />
