### PR TITLE
[refactor] 단골 api cursor 및 slice 적용

### DIFF
--- a/src/main/java/com/ureca/snac/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/ureca/snac/favorite/controller/FavoriteController.java
@@ -5,16 +5,18 @@ import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.CursorResult;
 import com.ureca.snac.favorite.dto.FavoriteCheckResponse;
 import com.ureca.snac.favorite.dto.FavoriteCreateRequest;
+import com.ureca.snac.favorite.dto.FavoriteListRequest;
 import com.ureca.snac.favorite.dto.FavoriteMemberDto;
 import com.ureca.snac.favorite.service.FavoriteService;
 import com.ureca.snac.swagger.annotation.UserInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import static com.ureca.snac.common.BaseCode.*;
 
@@ -37,18 +39,14 @@ public class FavoriteController implements FavoriteSwagger {
 
     @Override
     public ResponseEntity<ApiResponse<CursorResult<FavoriteMemberDto>>> getMyFavorites(
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime cursorCreatedAt,
-            @RequestParam(required = false) Long cursorId,
-            @RequestParam(required = false, defaultValue = "10")
-            Integer size,
+            @ParameterObject @Valid FavoriteListRequest request,
             @UserInfo CustomUserDetails userDetails) {
 
         String currentUserEmail = userDetails.getUsername();
+
         CursorResult<FavoriteMemberDto> result =
                 favoriteService.getMyFavorites(
-                        currentUserEmail, cursorCreatedAt, cursorId, size);
+                        currentUserEmail, request);
 
         return ResponseEntity.ok(ApiResponse.of(FAVORITE_LIST_SUCCESS, result));
     }

--- a/src/main/java/com/ureca/snac/favorite/controller/FavoriteSwagger.java
+++ b/src/main/java/com/ureca/snac/favorite/controller/FavoriteSwagger.java
@@ -5,6 +5,7 @@ import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.CursorResult;
 import com.ureca.snac.favorite.dto.FavoriteCheckResponse;
 import com.ureca.snac.favorite.dto.FavoriteCreateRequest;
+import com.ureca.snac.favorite.dto.FavoriteListRequest;
 import com.ureca.snac.favorite.dto.FavoriteMemberDto;
 import com.ureca.snac.swagger.annotation.UserInfo;
 import com.ureca.snac.swagger.annotation.error.ErrorCode400;
@@ -18,11 +19,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
 
 @Tag(name = "단골 관리",
         description = "단골 등록, 조회, 삭제와 관련된 API")
@@ -50,16 +49,8 @@ public interface FavoriteSwagger {
     @ErrorCode404(description = "사용자를 찾을 수 없습니다")
     @GetMapping
     ResponseEntity<ApiResponse<CursorResult<FavoriteMemberDto>>> getMyFavorites(
-            @Parameter(description = "이전 페이지의 마지막 항목의 생성 시간")
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime cursorCreatedAt,
 
-            @Parameter(description = "이전 페이지의 마지막 항목의 ID")
-            @RequestParam(required = false) Long cursorId,
-
-            @Parameter(description = "페이지에 보여줄 항목 수")
-            @RequestParam(required = false, defaultValue = "10") Integer size,
+            @ParameterObject @Valid FavoriteListRequest request,
             @UserInfo CustomUserDetails userDetails
     );
 

--- a/src/main/java/com/ureca/snac/favorite/dto/FavoriteListRequest.java
+++ b/src/main/java/com/ureca/snac/favorite/dto/FavoriteListRequest.java
@@ -1,0 +1,14 @@
+package com.ureca.snac.favorite.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+public record FavoriteListRequest(
+
+        @Schema(description = "다음 페이지 조회를 위한 커서 문자열, 이전 응답의 nextCursor 상요")
+        String cursor,
+
+        @Schema(description = "한 페이지에 보여줄 항복 수 ")
+        Integer size
+) {
+}

--- a/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepository.java
@@ -2,16 +2,12 @@ package com.ureca.snac.favorite.repository;
 
 import com.ureca.snac.favorite.entity.Favorite;
 import com.ureca.snac.member.Member;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+public interface FavoriteRepository extends JpaRepository<Favorite, Long>,
+        FavoriteRepositoryCustom {
     /**
      * 단골관계 있는지 여부 확인
      *
@@ -30,34 +26,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
      * @return 여부
      */
     Optional<Favorite> findByFromMemberAndToMember(Member findMember, Member toMember);
-
-
-    /**
-     * 최신 등록순 복합 커서 기반 페이지네이션
-     * createdAt 내림차랑 id 내림차
-     * 만약에 createdAt이 같을경우 에 대한 보험 id
-     * 특정 회원이 등록한 단골 목록 조회
-     * toMember를 fetch Join 사용
-     *
-     * @param fromMember      단골 목록 조회하고 싶은 회원
-     * @param cursorCreatedAt 이전 페이지 마지막 항목의 생성 시간
-     * @param cursorId        이전 페이지의 마지막 항목의 ID
-     * @param pageable        페이지 크기정보
-     * @return 단골 목록 Slice
-     */
-    @Query("""
-            select f from Favorite f JOIN fetch f.toMember
-            where f.fromMember = :fromMember and
-            (f.createdAt < :cursorCreatedAt or (f.createdAt = : cursorCreatedAt
-            and f.id < :cursorId))
-            order by f.createdAt desc, f.id desc
-            """)
-    Slice<Favorite> findAllWithToMemberByCursor(
-            @Param("fromMember") Member fromMember,
-            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable);
-
 
     /**
      * 특정 사용자가 등록한 단골 수 조회

--- a/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepositoryCustom.java
+++ b/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.ureca.snac.favorite.repository;
+
+import com.ureca.snac.favorite.dto.FavoriteListRequest;
+import com.ureca.snac.favorite.entity.Favorite;
+import com.ureca.snac.member.Member;
+import org.springframework.data.domain.Slice;
+
+public interface FavoriteRepositoryCustom {
+    /**
+     * @param fromMember 단골 목록을 조회하는 회원
+     * @param request    커서와 페이지 크기 정보를 담은 요청 DTO
+     * @return 단골 목록 Slice
+     */
+    Slice<Favorite> findFavoritesByFromMember(Member fromMember,
+                                              FavoriteListRequest request);
+}

--- a/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepositoryCustomImpl.java
@@ -1,0 +1,78 @@
+package com.ureca.snac.favorite.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.snac.favorite.dto.FavoriteListRequest;
+import com.ureca.snac.favorite.entity.Favorite;
+import com.ureca.snac.member.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import static com.ureca.snac.favorite.entity.QFavorite.favorite;
+import static com.ureca.snac.member.QMember.member;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class FavoriteRepositoryCustomImpl implements FavoriteRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private static final int DEFAULT_SIZE = 10;
+
+    @Override
+    public Slice<Favorite> findFavoritesByFromMember(Member fromMember, FavoriteListRequest request) {
+
+        int pageSize = (request.size() == null || request.size() <= 0) ?
+                DEFAULT_SIZE : request.size();
+
+        List<Favorite> favoriteList = queryFactory
+                .selectFrom(favorite)
+                .join(favorite.toMember, member).fetchJoin()
+                .where(
+                        favorite.fromMember.eq(fromMember),
+                        cursorCondition(request.cursor())
+                )
+                .orderBy(favorite.createdAt.desc(), favorite.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (favoriteList.size() > pageSize) {
+            favoriteList.remove(pageSize);
+            hasNext = true;
+        }
+        return new SliceImpl<>(favoriteList, Pageable.unpaged(), hasNext);
+    }
+
+    // 커서 기반 페이징 조건 생성
+    private BooleanExpression cursorCondition(String cursorStr) {
+        if (cursorStr == null || cursorStr.isBlank()) {
+            return null;
+        }
+        try {
+            String[] parts = cursorStr.trim().split(",");
+            // StringTokenizer 는 레거시 코드라서 사용안함
+            if (parts.length != 2) {
+                log.warn("[커서 파싱 오류] 잘못된 형식의 커서가 입력, 첫 페이지로 조회 cursor : {}",
+                        cursorStr);
+                return null;
+            }
+            LocalDateTime cursorTime = LocalDateTime.parse(parts[0]);
+            Long cursorId = Long.parseLong(parts[1]);
+
+            return favorite.createdAt.lt(cursorTime)
+                    .or(favorite.createdAt.eq(cursorTime).and(favorite.id.lt(cursorId)));
+        } catch (ArrayIndexOutOfBoundsException | DateTimeParseException | NumberFormatException exception) {
+            log.warn("[커서 파싱 오류] 잘못된 형식의 커서가 입력, 첫페이지로 조회. cursor : {}", cursorStr);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/ureca/snac/favorite/service/FavoriteService.java
+++ b/src/main/java/com/ureca/snac/favorite/service/FavoriteService.java
@@ -2,9 +2,8 @@ package com.ureca.snac.favorite.service;
 
 
 import com.ureca.snac.common.CursorResult;
+import com.ureca.snac.favorite.dto.FavoriteListRequest;
 import com.ureca.snac.favorite.dto.FavoriteMemberDto;
-
-import java.time.LocalDateTime;
 
 public interface FavoriteService {
 
@@ -20,18 +19,13 @@ public interface FavoriteService {
      * 로그인한 사용자의 단골 목록을 커서 기반 페이지네이션 조회
      * 최신순으로 조회 복합 커서 기반임
      *
-     * @param fromUserEmail   단골 목록 조회하는 회원 이메일
-     * @param cursorCreatedAt 이전 페이지 마지막 항목의 생성 시간 null
-     * @param cursorId        이전페이지 마지막 항목 ID 첫페이지는 null
-     * @param size            조회할 페이지 크기 null 이면 기본값
+     * @param fromUserEmail 단골 목록 조회하는 회원 이메일
+     * @param request       커서와 페이지 크기를 정보를 담은 DTO
      * @return 커서 정보를 포함한 단골 회원 목록
      */
-
     CursorResult<FavoriteMemberDto> getMyFavorites(
             String fromUserEmail,
-            LocalDateTime cursorCreatedAt,
-            Long cursorId,
-            Integer size
+            FavoriteListRequest request
     );
 
     /**


### PR DESCRIPTION
## 📝 변경 사항

1. 단골 목록 조회 API 리팩토링 
2. 커서 기반 페이지네이션 로직 개선
3. 요청 DTO

## 🔍 변경 사항 세부 설명

- Favorite 도메인의 목록 조회 방식을 Asset 도메인과 통일
- 기존의 복합 파라미터 방식에서, 단일 String을 사용하는 커서(Opaque Cursor) 방식으로 변경
