### PR TITLE
refactor: SocialProvider 통합 및 소셜 로그인/연동 로직 리팩토링

### DIFF
--- a/src/main/java/com/ureca/snac/auth/exception/UnsupportedSocialProviderException.java
+++ b/src/main/java/com/ureca/snac/auth/exception/UnsupportedSocialProviderException.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.auth.exception;
+
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.common.exception.BusinessException;
+
+public class UnsupportedSocialProviderException extends BusinessException {
+    public UnsupportedSocialProviderException() {
+        super(BaseCode.UNSUPPORTED_SOCIAL_PROVIDER);
+    }
+}

--- a/src/main/java/com/ureca/snac/auth/oauth2/SocialProvider.java
+++ b/src/main/java/com/ureca/snac/auth/oauth2/SocialProvider.java
@@ -1,0 +1,24 @@
+package com.ureca.snac.auth.oauth2;
+
+import com.ureca.snac.auth.exception.UnsupportedSocialProviderException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialProvider {
+    NAVER("naver"),
+    GOOGLE("google"),
+    KAKAO("kakao");
+
+    private final String value;
+
+    public static SocialProvider fromValue(String value) {
+        for (SocialProvider socialProvider : values()) {
+            if (socialProvider.value.equalsIgnoreCase(value)) {
+                return socialProvider;
+            }
+        }
+        throw new UnsupportedSocialProviderException();
+    }
+}

--- a/src/main/java/com/ureca/snac/auth/repository/AuthRepository.java
+++ b/src/main/java/com/ureca/snac/auth/repository/AuthRepository.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.auth.repository;
 
 import com.ureca.snac.member.Member;
+import com.ureca.snac.auth.oauth2.SocialProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,7 +14,15 @@ public interface AuthRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
-    Member findByNaverId(String naverId);
-    Member findByGoogleId(String googleId);
-    Member findByKakaoId(String kakaoId);
+    Optional<Member> findByNaverId(String naverId);
+    Optional<Member> findByGoogleId(String googleId);
+    Optional<Member> findByKakaoId(String kakaoId);
+
+    default Optional<Member> findBySocialProviderId(SocialProvider provider, String providerId) {
+        return switch (provider) {
+            case NAVER  -> findByNaverId(providerId);
+            case GOOGLE -> findByGoogleId(providerId);
+            case KAKAO  -> findByKakaoId(providerId);
+        };
+    }
 }

--- a/src/main/java/com/ureca/snac/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ureca/snac/auth/service/CustomOAuth2UserService.java
@@ -8,6 +8,7 @@ import com.ureca.snac.auth.dto.response.OAuth2Response;
 import com.ureca.snac.auth.repository.AuthRepository;
 import com.ureca.snac.auth.util.JWTUtil;
 import com.ureca.snac.member.Member;
+import com.ureca.snac.auth.oauth2.SocialProvider;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.time.Duration;
+import java.util.Optional;
 
 
 @Service
@@ -39,28 +41,27 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         log.info("loadUser 메소드 시작");
         String accessToken = userRequest.getAccessToken().getTokenValue();
-        log.info("accessToken: {}", accessToken);
+        log.debug("OAuth2 accessToken={}", accessToken);
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        log.info("OAuth2 사용자 정보: {}", oAuth2User.getAttributes());
+        log.debug("OAuth2 사용자 정보={}", oAuth2User.getAttributes());
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialProvider provider = SocialProvider.fromValue(registrationId);
         log.info("registrationId: {}", registrationId);
-        OAuth2Response oAuth2Response = switch (registrationId) {
-            case "naver" -> new NaverResponse(oAuth2User.getAttributes());
-            case "google" -> new GoogleResponse(oAuth2User.getAttributes());
-            case "kakao" -> new KakaoResponse(oAuth2User.getAttributes());
-            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + registrationId);
+
+        OAuth2Response oAuth2Response = switch (provider) {
+            case NAVER  -> new NaverResponse(oAuth2User.getAttributes());
+            case GOOGLE -> new GoogleResponse(oAuth2User.getAttributes());
+            case KAKAO  -> new KakaoResponse(oAuth2User.getAttributes());
         };
 
-        String provider = oAuth2Response.getProvider();
         String providerId = oAuth2Response.getProviderId();
         log.info("provider: {}, providerId: {}", provider, providerId);
 
-        // 1) state 파라미터가 JWT로 디코딩되는지 시도해서 플로우 구분
+        // state 파라미터가 JWT로 디코딩되는지 시도해서 플로우 구분
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
         String state = request.getParameter("state");
-        log.info("state : {}", state);
 
         String emailFromState = null;
         boolean isLinking = true;
@@ -74,26 +75,27 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String redisKey = provider + ":" + providerId;
         stringRedisTemplate.opsForValue().set(redisKey, accessToken, Duration.ofMinutes(3));
-        log.info("AccessToken Redis 저장: {} = {}", redisKey, accessToken);
+        log.info("소셜 계정에서 내려준 AccessToken Redis 저장: {} = {}", redisKey, accessToken);
 
 
         if (isLinking) {
             // 소셜 연동
             // 이미 다른 계정에 해당 providerId가 연결되어 있는지 체크
-            Member alreadyLinked = switch (provider) {
-                case "naver" -> authRepository.findByNaverId(providerId);
-                case "google" -> authRepository.findByGoogleId(providerId);
-                default -> authRepository.findByKakaoId(providerId);
-            };
-            if (alreadyLinked != null) {
-                // 이미 다른 계정에 연동된 소셜 계정
-                log.info("이미 다른 계정에 연동된 소셜 계정");
+            Optional<Member> alreadyLinked =
+                    authRepository.findBySocialProviderId(provider, providerId);
+            if (alreadyLinked.isPresent()) {
+                log.warn("이미 연동된 소셜 계정: provider={}, id={}", provider, providerId);
                 throw new OAuth2AuthenticationException("이미 다른 계정에 연동된 소셜 계정입니다.");
             }
 
             // 연동 대상 회원 조회 및 ID 업데이트
-            Member member = authRepository.findByEmail(emailFromState)
-                    .orElseThrow(() -> new OAuth2AuthenticationException("존재하지 않는 회원입니다."));
+            Optional<Member> email = authRepository.findByEmail(emailFromState);
+            if (email.isEmpty()) {
+                log.error("존재하지 않는 회원 이메일: {}", emailFromState);
+                throw new OAuth2AuthenticationException("존재하지 않는 회원입니다.");
+            }
+            Member member = email.get();
+
             member.updateSocialId(provider, providerId);
             authRepository.save(member);
             log.info("social 연동 완료: {} -> {}", member.getEmail(), provider);
@@ -102,18 +104,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
 
         // -----------------------------------소셜 로그인 ---------------------------------------
-        Member existingMember = switch (provider) {
-            case "naver" -> authRepository.findByNaverId(providerId);
-            case "google" -> authRepository.findByGoogleId(providerId);
-            default -> authRepository.findByKakaoId(providerId);
-        };
-        if (existingMember != null) {
-            log.info("기존 회원 로그인: {}", existingMember.getEmail());
-            return new CustomOAuth2User(existingMember, registrationId, providerId, oAuth2User.getAttributes());
-        }
+        Member existingMember = authRepository
+                .findBySocialProviderId(provider, providerId)
+                .orElseThrow(() -> {
+                    log.warn("일치하는 소셜 계정 없음: provider={}, id={}", provider, providerId);
+                    return new OAuth2AuthenticationException("일치하는 계정이 없습니다.");
+                });
 
-        // (필요시!!!!!!!!!!) 신규 회원 가입 로직 추가
-        log.info("일치하는 계정이 없음.");
-        throw new OAuth2AuthenticationException("일치하는 계정이 없습니다.");
+        log.info("기존 회원 로그인: email={}", existingMember.getEmail());
+        return new CustomOAuth2User(existingMember, provider.getValue(), providerId, oAuth2User.getAttributes()
+        );
     }
 }

--- a/src/main/java/com/ureca/snac/auth/service/JoinServiceImpl.java
+++ b/src/main/java/com/ureca/snac/auth/service/JoinServiceImpl.java
@@ -81,6 +81,7 @@ public class JoinServiceImpl implements JoinService {
                 .build();
 
         authRepository.save(member);
+        log.info("회원가입 완료됨! : 이메일 : {}, 이름 : {}", member.getEmail(),member.getName());
 
         // 여기서 이벤트 발행 서비스 동작
         publishMemberJoinEvent(member);

--- a/src/main/java/com/ureca/snac/auth/service/unlink/GoogleUnlinkServiceImpl.java
+++ b/src/main/java/com/ureca/snac/auth/service/unlink/GoogleUnlinkServiceImpl.java
@@ -5,6 +5,7 @@ import com.ureca.snac.auth.exception.SocialUnlinkException;
 import com.ureca.snac.auth.repository.AuthRepository;
 import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.member.Member;
+import com.ureca.snac.auth.oauth2.SocialProvider;
 import com.ureca.snac.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +65,7 @@ public class GoogleUnlinkServiceImpl implements GoogleUnlinkService {
             throw new SocialUnlinkApiException(BaseCode.GOOGLE_UNLINK_FAILED, "구글 API 호출 실패: " + e.getMessage());
         }
 
-        member.updateSocialId("google", null);
+        member.updateSocialId(SocialProvider.GOOGLE, null);
         stringRedisTemplate.delete(redisKey);
         log.info("구글 연동 해제 완료: {}", email);
     }

--- a/src/main/java/com/ureca/snac/auth/service/unlink/KakaoUnlinkServiceImpl.java
+++ b/src/main/java/com/ureca/snac/auth/service/unlink/KakaoUnlinkServiceImpl.java
@@ -6,6 +6,7 @@ import com.ureca.snac.auth.exception.SocialUnlinkApiException;
 import com.ureca.snac.auth.repository.AuthRepository;
 import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.member.Member;
+import com.ureca.snac.auth.oauth2.SocialProvider;
 import com.ureca.snac.member.exception.MemberNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -62,7 +63,7 @@ public class KakaoUnlinkServiceImpl implements KakaoUnlinkService {
                 throw new SocialUnlinkApiException(BaseCode.KAKAO_API_CALL_ERROR);
             }
 
-            member.updateSocialId("kakao", null);
+            member.updateSocialId(SocialProvider.KAKAO, null);
 
             log.info("카카오 연동 해제 완료.");
             return response.id();

--- a/src/main/java/com/ureca/snac/auth/service/unlink/NaverUnlinkServiceImpl.java
+++ b/src/main/java/com/ureca/snac/auth/service/unlink/NaverUnlinkServiceImpl.java
@@ -6,6 +6,7 @@ import com.ureca.snac.auth.exception.SocialUnlinkException;
 import com.ureca.snac.auth.repository.AuthRepository;
 import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.member.Member;
+import com.ureca.snac.auth.oauth2.SocialProvider;
 import com.ureca.snac.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,7 +73,7 @@ public class NaverUnlinkServiceImpl implements NaverUnlinkService {
                     .retrieve()
                     .body(NaverUnlinkResponse.class);
 
-            member.updateSocialId("naver", null);
+            member.updateSocialId(SocialProvider.NAVER, null);
             stringRedisTemplate.delete(redisKey);
             log.info("네이버 연동 해제 완료: {}", email);
 

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -31,6 +31,7 @@ public enum BaseCode {
 
     // 소셜 로그인 시도 - 실패
     OAUTH_LOGIN_FAILED("OAUTH_LOGIN_FAILED_401", HttpStatus.UNAUTHORIZED, "회원이 아니거나, 소셜 연동이 되어 있지 않습니다."),
+    UNSUPPORTED_SOCIAL_PROVIDER("UNSUPPORTED_SOCIAL_PROVIDER_400", HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 프로바이더입니다."),
 
     // 카카오 연동 해제 관련
     KAKAO_UNLINK_SUCCESS("KAKAO_UNLINK_SUCCESS_200", HttpStatus.OK, "카카오 연결 끊기에 성공했습니다."),

--- a/src/main/java/com/ureca/snac/member/Member.java
+++ b/src/main/java/com/ureca/snac/member/Member.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.member;
 
+import com.ureca.snac.auth.oauth2.SocialProvider;
 import com.ureca.snac.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -84,18 +85,21 @@ public class Member extends BaseTimeEntity {
     }
 
     // 소셜 아이디 업데이트 용
-    public void updateSocialId(String provider, String providerId) {
+    public void updateSocialId(SocialProvider provider, String providerId) {
         switch (provider) {
-            case "naver":
-                this.naverId = providerId;
-                break;
-            case "google":
-                this.googleId = providerId;
-                break;
-            case "kakao":
-                this.kakaoId = providerId;
-                break;
+            case NAVER -> this.naverId = providerId;
+            case GOOGLE -> this.googleId = providerId;
+            case KAKAO -> this.kakaoId = providerId;
         }
+    }
+
+    // 연결됐는지 확인
+    public boolean isConnected(SocialProvider provider) {
+        return switch (provider) {
+            case NAVER -> naverId != null && !naverId.isEmpty();
+            case GOOGLE -> googleId != null && !googleId.isEmpty();
+            case KAKAO -> kakaoId != null && !kakaoId.isEmpty();
+        };
     }
 
     public void changePasswordTo(String encodedPassword) {
@@ -127,17 +131,5 @@ public class Member extends BaseTimeEntity {
     public void activate() {
         this.activated = Activated.NORMAL;
         this.suspendUntil = null;
-    }
-
-    public boolean isNaverConnected() {
-        return naverId != null && !naverId.isEmpty();
-    }
-
-    public boolean isGoogleConnected() {
-        return googleId != null && !googleId.isEmpty();
-    }
-
-    public boolean isKakaoConnected() {
-        return kakaoId != null && !kakaoId.isEmpty();
     }
 }

--- a/src/main/java/com/ureca/snac/member/Member.java
+++ b/src/main/java/com/ureca/snac/member/Member.java
@@ -128,4 +128,16 @@ public class Member extends BaseTimeEntity {
         this.activated = Activated.NORMAL;
         this.suspendUntil = null;
     }
+
+    public boolean isNaverConnected() {
+        return naverId != null && !naverId.isEmpty();
+    }
+
+    public boolean isGoogleConnected() {
+        return googleId != null && !googleId.isEmpty();
+    }
+
+    public boolean isKakaoConnected() {
+        return kakaoId != null && !kakaoId.isEmpty();
+    }
 }

--- a/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
+++ b/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import static com.ureca.snac.auth.oauth2.SocialProvider.*;
+
 @Getter
 @Builder(toBuilder = true)
 public class MyPageResponse {
@@ -29,9 +31,9 @@ public class MyPageResponse {
                 .score(member.getRatingScore())
                 .nickname(member.getNickname())
                 .nicknameUpdatedAt(member.getNicknameUpdatedAt())
-                .isNaverConnected(member.isNaverConnected())
-                .isGoogleConnected(member.isGoogleConnected())
-                .isKakaoConnected(member.isKakaoConnected())
+                .isNaverConnected(member.isConnected(NAVER))
+                .isGoogleConnected(member.isConnected(GOOGLE))
+                .isKakaoConnected(member.isConnected(KAKAO))
                 .build();
     }
 }

--- a/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
+++ b/src/main/java/com/ureca/snac/mypage/dto/MyPageResponse.java
@@ -29,9 +29,9 @@ public class MyPageResponse {
                 .score(member.getRatingScore())
                 .nickname(member.getNickname())
                 .nicknameUpdatedAt(member.getNicknameUpdatedAt())
-                .isNaverConnected(member.getNaverId() != null && !member.getNaverId().isEmpty())
-                .isGoogleConnected(member.getGoogleId() != null && !member.getGoogleId().isEmpty())
-                .isKakaoConnected(member.getKakaoId() != null && !member.getKakaoId().isEmpty())
+                .isNaverConnected(member.isNaverConnected())
+                .isGoogleConnected(member.isGoogleConnected())
+                .isKakaoConnected(member.isKakaoConnected())
                 .build();
     }
 }


### PR DESCRIPTION
## 📝 변경 사항

SocialProvider 통합 및 소셜 로그인/연동 로직 리팩토링

Member 엔티티에 updateSocialId 및 isConnected 메서드 추가

AuthRepository에 findBySocialProviderId 메서드 도입 및 중복 메서드 제거

CustomOAuth2UserService, SocialLoginServiceImpl, UnlinkServiceImpl 등에서 SocialProvider enum 사용으로 분기 로직 개선

UnsupportedSocialProviderException 및 BaseCode 리팩토링

MyPageResponse DTO에서 소셜 연결 상태 판별 로직을 엔티티 메서드 호출로 변경

## 🔍 변경 사항 세부 설명

### SocialProvider enum 통합

com.ureca.snac.auth.oauth2.SocialProvider 에서 fromValue 메서드 도입, 지원하지 않는 값에 UnsupportedSocialProviderException 발생

기존 문자열 비교 대신 enum 기반 분기 처리로 안정성 향상

### Member 엔티티 개선

updateSocialId(SocialProvider, String) 메서드로 provider별 ID 업데이트 로직 통합

isConnected(SocialProvider) 메서드 추가하여 소셜 연결 여부 확인 책임을 엔티티로 이전

###  AuthRepository 리팩토링

findBySocialProviderId(SocialProvider, String) 메서드로 한 번에 조회하도록 변경

기존 findByNaverId·findByGoogleId·findByKakaoId 중복 정의 제거

###  서비스 로직 개선

CustomOAuth2UserService에서 registrationId → SocialProvider enum 전환, switch-case 간소화

SocialLoginServiceImpl, GoogleUnlinkServiceImpl·KakaoUnlinkServiceImpl·NaverUnlinkServiceImpl에서 문자열 비교 대신 enum 사용

### 예외 및 에러 코드 정리

UnsupportedSocialProviderException 추가

BaseCode에 UNSUPPORTED_SOCIAL_PROVIDER 항목 추가

###  DTO 변경

MyPageResponse.from(Member)에서 member.isConnected(...) 호출로 연결 상태 판별 로직 단순화

###  기타

로깅 메시지 및 변수명 통일을 통해 가독성 및 유지보수성 개선

불필요한 중복 코드 제거 및 import 정리

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 