### PR TITLE
[fix] 실시간 매칭 데드락 문제 해결

### DIFF
--- a/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
+++ b/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
@@ -71,7 +71,6 @@ public class WebSocketTradeEventListener {
 
     // 소켓 해제시 호출
     @EventListener
-    @Transactional
     public void handleSessionDisconnect(SessionDisconnectEvent event) {
         String username = extractUsername(event);
         if (username == null) return;
@@ -132,10 +131,6 @@ public class WebSocketTradeEventListener {
         List<TradeDto> buyerTrades = tradeQueryService.findBuyerRealTimeTrade(username);
         for (TradeDto trade : buyerTrades) {
             if (isCancellable(trade.getStatus())) {
-//                if (trade.getStatus() == PAYMENT_CONFIRMED) {
-//                    tradeCancelService.cancelRealTimeTradeWithRefund(trade.getId(), trade.getBuyer());
-//                }
-
                 TradeDto tradeDto = tradeCancelService.cancelRealTimeTrade(
                         trade.getTradeId(),
                         username,
@@ -154,10 +149,6 @@ public class WebSocketTradeEventListener {
         List<TradeDto> sellerTrades = tradeQueryService.findSellerRealTimeTrade(username);
         for (TradeDto trade : sellerTrades) {
             if (isCancellable(trade.getStatus())) {
-//                if (trade.getStatus() == PAYMENT_CONFIRMED) {
-//                    tradeCancelService.cancelRealTimeTradeWithRefund(trade.getId(), trade.getBuyer());
-//                }
-
                 TradeDto tradeDto = tradeCancelService.cancelRealTimeTrade(
                         trade.getTradeId(),
                         username,


### PR DESCRIPTION
## 📝 변경 사항

1. handleSessionDisconnect 메서드에서 @Transactional 제거
2. 분산 락은 그대로 유지하고, 내부 서비스 호출은 각기 별도 트랜잭션으로 수행하도록 수정

## 🔍 변경 사항 세부 설명

- 기존에는 handleSessionDisconnect 전체를 하나의 트랜잭션으로 묶어 분산 락 + 비관적 락을 장시간 점유하면서 데드락이 발생
- 이제 이벤트 핸들러에서는 분산 락만 획득하고, 실제 DB 조작(강제 종료, 카드 삭제 등)은 서비스 계층에서 개별 트랜잭션으로 실행되도록 변경
- 덕분에 분산 락 해제 후에만 DB 락이 걸려 트랜잭션 점유 시간이 크게 단축되어 데드락 상황이 해소됨

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 