### PR TITLE
fix: 게시글 제목이 누락되는 문제 해결

### DIFF
--- a/src/main/java/com/ureca/snac/board/service/response/ArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/ArticleResponse.java
@@ -24,6 +24,7 @@ public class ArticleResponse {
                 .nickname(article.getMember().getNickname())
                 .articleUrl(generateArticleKey)
                 .imageUrl(generateImageKey)
+                .title(article.getTitle())
                 .build();
     }
 


### PR DESCRIPTION
## 📝 변경 사항

1. 게시글 제목이 누락되는 문제를 수정했습니다.

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 