### PR TITLE
[feat] retrieve members and posts count

### DIFF
--- a/src/main/java/com/ureca/snac/board/controller/ArticleController.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleController.java
@@ -1,10 +1,7 @@
 package com.ureca.snac.board.controller;
 
 import com.ureca.snac.board.service.ArticleService;
-import com.ureca.snac.board.service.response.ArticleResponse;
-import com.ureca.snac.board.service.response.CreateArticleResponse;
-import com.ureca.snac.board.service.response.ListArticleResponse;
-import com.ureca.snac.board.service.response.UpdateArticleResponse;
+import com.ureca.snac.board.service.response.*;
 import com.ureca.snac.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,5 +67,11 @@ public class ArticleController implements ArticleControllerSwagger {
 
         return ResponseEntity
                 .ok(ApiResponse.of(ACCOUNT_LIST_SUCCESS, articleService.getArticles(lastArticleId, size)));
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<ApiResponse<CountArticleResponse>> countArticles(@AuthenticationPrincipal UserDetails userDetails) {
+        CountArticleResponse count = articleService.countArticle();
+        return ResponseEntity.ok(ApiResponse.of(ARTICLE_COUNT_SUCCESS, count));
     }
 }

--- a/src/main/java/com/ureca/snac/board/controller/ArticleControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/board/controller/ArticleControllerSwagger.java
@@ -1,9 +1,6 @@
 package com.ureca.snac.board.controller;
 
-import com.ureca.snac.board.service.response.ArticleResponse;
-import com.ureca.snac.board.service.response.CreateArticleResponse;
-import com.ureca.snac.board.service.response.ListArticleResponse;
-import com.ureca.snac.board.service.response.UpdateArticleResponse;
+import com.ureca.snac.board.service.response.*;
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.swagger.annotation.error.ErrorCode400;
 import com.ureca.snac.swagger.annotation.error.ErrorCode401;
@@ -100,4 +97,13 @@ public interface ArticleControllerSwagger {
             @Parameter(description = "마지막으로 조회한 게시글 ID(커서)") @RequestParam(required = false) Long lastArticleId,
             @Parameter(description = "페이지 당 조회 개수", example = "9") @RequestParam(defaultValue = "9") Integer size
     );
+
+    @Operation(
+            summary = "게시글 개수 조회",
+            description = "전체 게시글 수를 반환합니다."
+    )
+    @ApiSuccessResponse(description = "게시글 개수 조회 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자 접근")
+    @GetMapping("/count")
+    ResponseEntity<ApiResponse<CountArticleResponse>> countArticles(@AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
+++ b/src/main/java/com/ureca/snac/board/repository/ArticleRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface ArticleRepository extends JpaRepository<Article, Long>, ArticleRepositoryCustom {
 
     Optional<Article> findByMemberAndId(Member member, Long articleId);
+
+    long count();
 }

--- a/src/main/java/com/ureca/snac/board/service/ArticleService.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleService.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.board.service;
 
 import com.ureca.snac.board.service.response.ArticleResponse;
+import com.ureca.snac.board.service.response.CountArticleResponse;
 import com.ureca.snac.board.service.response.ListArticleResponse;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,4 +15,6 @@ public interface ArticleService {
     Long updateArticle(Long articleId, String title, MultipartFile file, MultipartFile image, String username);
 
     void deleteArticle(Long articleId, String username);
+
+    CountArticleResponse countArticle();
 }

--- a/src/main/java/com/ureca/snac/board/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ureca/snac/board/service/ArticleServiceImpl.java
@@ -4,6 +4,7 @@ import com.ureca.snac.board.entity.Article;
 import com.ureca.snac.board.exception.ArticleNotFoundException;
 import com.ureca.snac.board.repository.ArticleRepository;
 import com.ureca.snac.board.service.response.ArticleResponse;
+import com.ureca.snac.board.service.response.CountArticleResponse;
 import com.ureca.snac.board.service.response.ListArticleResponse;
 import com.ureca.snac.common.s3.S3Path;
 import com.ureca.snac.common.s3.S3Uploader;
@@ -110,5 +111,10 @@ public class ArticleServiceImpl implements ArticleService {
         s3Uploader.delete(article.getImageUrl());
 
         articleRepository.delete(article);
+    }
+
+    @Override
+    public CountArticleResponse countArticle() {
+        return new CountArticleResponse(articleRepository.count());
     }
 }

--- a/src/main/java/com/ureca/snac/board/service/response/CountArticleResponse.java
+++ b/src/main/java/com/ureca/snac/board/service/response/CountArticleResponse.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.board.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CountArticleResponse {
+
+    private Long articleCount;
+}

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -116,6 +116,8 @@ public enum BaseCode {
     ARTICLE_LIST_SUCCESS("ARTICLE_LIST_SUCCESS_200", HttpStatus.OK, "게시글 목록을 성공적으로 조회했습니다."),
     ARTICLE_UPDATE_SUCCESS("ARTICLE_UPDATE_SUCCESS_200", HttpStatus.OK, "게시글이 성공적으로 수정되었습니다."),
     ARTICLE_DELETE_SUCCESS("ARTICLE_DELETE_SUCCESS_200", HttpStatus.OK, "게시글이 성공적으로 삭제되었습니다."),
+    ARTICLE_COUNT_SUCCESS("ARTICLE_COUNT_SUCCESS_200", HttpStatus.OK, "전체 게시글 수를 성공적으로 조회했습니다."),
+
 
     // 게시글 - 실패
     ARTICLE_NOT_FOUND("ARTICLE_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -192,6 +192,9 @@ public enum BaseCode {
     INCONSISTENT_TRANSACTION_TYPE("INCONSISTENT_TRANSACTION_TYPE_409", HttpStatus.CONFLICT, "거래 타입과 카테고리가 일치하지 않습니다"),
     INVALID_ASSET_CATEGORY_COMBINATION("INVALID_ASSET_CATEGORY_COMBINATION_409", HttpStatus.CONFLICT, "자산 타입과 카테고리의 조합이 유효하지 않습니다"),
 
+    // 회원 - 성공
+    MEMBER_COUNT_SUCCESS("MEMBER_COUNT_SUCCESS_200", HttpStatus.OK, "전체 회원 수를 성공적으로 조회했습니다."),
+
     // 회원 - 예외
     MEMBER_NOT_FOUND("MEMBER_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
 

--- a/src/main/java/com/ureca/snac/member/controller/MemberController.java
+++ b/src/main/java/com/ureca/snac/member/controller/MemberController.java
@@ -7,10 +7,13 @@ import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.config.RabbitMQConfig;
 import com.ureca.snac.member.dto.request.*;
+import com.ureca.snac.member.dto.response.CountMemberResponse;
 import com.ureca.snac.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -155,6 +158,12 @@ public class MemberController implements MemberControllerSwagger {
         }
         memberService.resetPasswordByEmail(email, req.getNewPwd());
         return ResponseEntity.ok(ApiResponse.ok(BaseCode.PASSWORD_CHANGED));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<CountMemberResponse>> countMembers(@AuthenticationPrincipal UserDetails userDetails) {
+        CountMemberResponse count = memberService.countMember();
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.MEMBER_COUNT_SUCCESS, count));
     }
 }
 

--- a/src/main/java/com/ureca/snac/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/member/controller/MemberControllerSwagger.java
@@ -3,6 +3,7 @@ package com.ureca.snac.member.controller;
 import com.ureca.snac.auth.dto.CustomUserDetails;
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.member.dto.request.*;
+import com.ureca.snac.member.dto.response.CountMemberResponse;
 import com.ureca.snac.swagger.annotation.UserInfo;
 import com.ureca.snac.swagger.annotation.error.*;
 import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
@@ -11,6 +12,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -103,4 +107,10 @@ public interface MemberControllerSwagger {
     @PostMapping("/find-pwd/email")
     ResponseEntity<ApiResponse<Void>> resetPwdByEmail(
             @Valid @RequestBody PasswordResetByEmailRequest req);
+
+    @Operation(summary = "회원 수 조회", description = "전체 회원 수를 조회합니다.")
+    @ApiSuccessResponse(description = "전체 회원 수 조회 성공")
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping("/count")
+    ResponseEntity<ApiResponse<CountMemberResponse>> countMembers(@AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/com/ureca/snac/member/dto/response/CountMemberResponse.java
+++ b/src/main/java/com/ureca/snac/member/dto/response/CountMemberResponse.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CountMemberResponse {
+
+    private Long memberCount;
+}

--- a/src/main/java/com/ureca/snac/member/repository/MemberRepository.java
+++ b/src/main/java/com/ureca/snac/member/repository/MemberRepository.java
@@ -26,4 +26,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmail(String email);
 
+    long count();
 }

--- a/src/main/java/com/ureca/snac/member/service/MemberService.java
+++ b/src/main/java/com/ureca/snac/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.member.service;
 
 import com.ureca.snac.member.dto.request.*;
+import com.ureca.snac.member.dto.response.CountMemberResponse;
 
 public interface MemberService {
 
@@ -19,4 +20,6 @@ public interface MemberService {
     void resetPasswordByPhone(String phone, String newPwd);
 
     void resetPasswordByEmail(String email, String newPwd);
+
+    CountMemberResponse countMember();
 }

--- a/src/main/java/com/ureca/snac/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ureca/snac/member/service/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import com.ureca.snac.member.Member;
 import com.ureca.snac.member.dto.request.NicknameChangeRequest;
 import com.ureca.snac.member.dto.request.PasswordChangeRequest;
 import com.ureca.snac.member.dto.request.PhoneChangeRequest;
+import com.ureca.snac.member.dto.response.CountMemberResponse;
 import com.ureca.snac.member.exception.InvalidCurrentMemberInfoException;
 import com.ureca.snac.member.exception.MemberNotFoundException;
 import com.ureca.snac.member.exception.NicknameDuplicateException;
@@ -92,5 +93,10 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(MemberNotFoundException::new);
 
         member.changePasswordTo(passwordEncoder.encode(newPwd));
+    }
+
+    @Override
+    public CountMemberResponse countMember() {
+        return new CountMemberResponse(memberRepository.count());
     }
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 전체 게시글 수 조회를 위한 API를 추가했습니다.
2. 전체 회원 수 조회를 위한 API를 추가했습니다.

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 