### PR TITLE
[feat] 실시간 매칭 거래 소요 시간 통계 기능

### DIFF
--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -271,6 +271,12 @@ public enum BaseCode {
     AUTO_REFUND_SUCCESS("AUTO_REFUND_SUCCESS_200", HttpStatus.OK, "판매자 지연으로 자동 환불되었습니다."),
     AUTO_PAYOUT_SUCCESS("AUTO_PAYOUT_SUCCESS_200", HttpStatus.OK, "구매자 미확정으로 자동 정산되었습니다."),
 
+    // 거래 소요 시간 통계 - 성공
+    TRADE_DURATION_STATISTIC_READ_SUCCESS("TRADE_DURATION_STATISTIC_READ_SUCCESS_200", HttpStatus.OK, "거래 소요 시간 통계 데이터를 성공적으로 조회했습니다."),
+
+    // 거래 소요 시간 통계 - 실패
+    TRADE_DURATION_STATISTIC_NOT_FOUND("TRADE_DURATION_STATISTIC_NOT_FOUND_404", HttpStatus.NOT_FOUND, "해당 거래 소요 시간 통계 데이터를 찾을 수 없습니다."),
+
     // 신고 예외
     DISPUTE_PERMISSION_DENIED("DISPUTE_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "거래 당사자만 신고할 수 있습니다."),
     DISPUTE_ADMIN_PERMISSION_DENIED("DISPUTE_ADMIN_PERMISSION_DENIED_403", HttpStatus.FORBIDDEN, "관리자 아니야"),

--- a/src/main/java/com/ureca/snac/trade/controller/TradeDurationStatisticController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/TradeDurationStatisticController.java
@@ -1,0 +1,24 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.trade.service.interfaces.TradeDurationStatisticService;
+import com.ureca.snac.trade.service.response.TradeDurationStatisticResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TradeDurationStatisticController implements TradeDurationStatisticControllerSwagger{
+
+    private final TradeDurationStatisticService tradeDurationStatisticService;
+
+    @GetMapping("/api/trade-duration-statistics")
+    public ResponseEntity<ApiResponse<TradeDurationStatisticResponse>> getLatestStatistic() {
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.TRADE_DURATION_STATISTIC_READ_SUCCESS, tradeDurationStatisticService.getLatestStatistic()));
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/controller/TradeDurationStatisticControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/TradeDurationStatisticControllerSwagger.java
@@ -1,0 +1,25 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import com.ureca.snac.trade.service.response.TradeDurationStatisticResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "거래 소요 시간 통계", description = "실시간 매칭 거래 소요 시간(평균 등) 통계 조회 기능")
+public interface TradeDurationStatisticControllerSwagger {
+
+    @Operation(
+            summary = "가장 최근 거래 소요 시간 통계 조회",
+            description = """
+            가장 최근에 저장된 실시간 매칭 거래의 평균 소요 시간 통계 데이터를 조회합니다.
+        """
+    )
+    @ApiSuccessResponse(description = "거래 소요 시간 통계 데이터 조회 성공")
+    @ErrorCode404(description = "조회 실패 - 통계 데이터 없음")
+    @GetMapping("/api/trade-duration-statistics")
+    ResponseEntity<ApiResponse<TradeDurationStatisticResponse>> getLatestStatistic();
+}

--- a/src/main/java/com/ureca/snac/trade/entity/TradeDurationStatistic.java
+++ b/src/main/java/com/ureca/snac/trade/entity/TradeDurationStatistic.java
@@ -1,0 +1,27 @@
+package com.ureca.snac.trade.entity;
+
+import com.ureca.snac.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "trade_duration_statistic")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TradeDurationStatistic extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long durationSeconds;
+
+    @Builder
+    private TradeDurationStatistic(Long durationSeconds) {
+        this.durationSeconds = durationSeconds;
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/exception/TradeDurationStatisticNotFoundException.java
+++ b/src/main/java/com/ureca/snac/trade/exception/TradeDurationStatisticNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ureca.snac.trade.exception;
+
+import com.ureca.snac.common.exception.BusinessException;
+
+import static com.ureca.snac.common.BaseCode.TRADE_DURATION_STATISTIC_NOT_FOUND;
+
+public class TradeDurationStatisticNotFoundException extends BusinessException {
+    public TradeDurationStatisticNotFoundException() {
+        super(TRADE_DURATION_STATISTIC_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/repository/TradeDurationStatisticRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeDurationStatisticRepository.java
@@ -1,0 +1,13 @@
+package com.ureca.snac.trade.repository;
+
+import com.ureca.snac.trade.entity.TradeDurationStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TradeDurationStatisticRepository extends JpaRepository<TradeDurationStatistic, Long> {
+
+    Optional<TradeDurationStatistic> findTopByOrderByCreatedAtDesc();
+}

--- a/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeRepository.java
@@ -75,4 +75,5 @@ public interface TradeRepository extends JpaRepository<Trade, Long>, CustomTrade
     @Lock(PESSIMISTIC_WRITE)
     Optional<Trade> findByBuyerAndStatus(Member member, TradeStatus status);
 
+    List<Trade> findByTradeTypeAndStatusAndUpdatedAtBetween(TradeType tradeType, TradeStatus status, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/ureca/snac/trade/scheduler/TradeDurationScheduler.java
+++ b/src/main/java/com/ureca/snac/trade/scheduler/TradeDurationScheduler.java
@@ -1,0 +1,70 @@
+package com.ureca.snac.trade.scheduler;
+
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeDurationStatistic;
+import com.ureca.snac.trade.entity.TradeStatus;
+import com.ureca.snac.trade.entity.TradeType;
+import com.ureca.snac.trade.repository.TradeDurationStatisticRepository;
+import com.ureca.snac.trade.repository.TradeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.time.Duration.between;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TradeDurationScheduler {
+
+    private final TradeRepository tradeRepository;
+    private final TradeDurationStatisticRepository tradeDurationStatisticRepository;
+
+    @Scheduled(cron = "0 0 * * * *")
+//    @Scheduled(cron = "0 * * * * *")
+    @SchedulerLock(
+            name = "recordHourlyAverageDuration",
+            lockAtMostFor = "PT59M",
+            lockAtLeastFor = "PT1M"
+    )
+    public void recordHourlyAverageDuration() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime since = now.minusHours(24);
+
+        List<Trade> trades = tradeRepository
+                .findByTradeTypeAndStatusAndUpdatedAtBetween(
+                        TradeType.REALTIME,
+                        TradeStatus.COMPLETED,
+                        since,
+                        now
+                );
+
+        if (trades.isEmpty()) {
+            log.info("지난 24시간 동안 COMPLETED 상태의 REALTIME 거래가 없어 평균 소요 시간 계산을 건너뜁니다.");
+            return;
+        }
+
+        // 총 소요 시간 (초) 합산
+        long sumSeconds = trades.stream()
+                .mapToLong(trade -> between(trade.getCreatedAt(), trade.getUpdatedAt()).getSeconds())
+                .sum();
+
+        long avgSeconds = (long) (sumSeconds / trades.size()); // 평균 소유 시간 (초, 소수점 절삭)
+
+        log.info("지난 24시간 REALTIME 거래 건수: {}, 평균 소요 시간: {}초", trades.size(), avgSeconds);
+
+        // 저장
+        TradeDurationStatistic stat = TradeDurationStatistic.builder()
+                .durationSeconds(avgSeconds)
+                .build();
+
+        tradeDurationStatisticRepository.save(stat);
+
+        log.info("평균 소요 시간을 trade_duration_statistic 테이블에 저장했습니다. (평균: {}초, 저장 시각: {})", avgSeconds, now);
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeDurationStatisticServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeDurationStatisticServiceImpl.java
@@ -1,0 +1,29 @@
+package com.ureca.snac.trade.service;
+
+import com.ureca.snac.trade.entity.TradeDurationStatistic;
+import com.ureca.snac.trade.exception.TradeDurationStatisticNotFoundException;
+import com.ureca.snac.trade.repository.TradeDurationStatisticRepository;
+import com.ureca.snac.trade.service.interfaces.TradeDurationStatisticService;
+import com.ureca.snac.trade.service.response.TradeDurationStatisticResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class TradeDurationStatisticServiceImpl implements TradeDurationStatisticService {
+
+    private TradeDurationStatisticRepository tradeDurationStatisticRepository;
+
+    @Override
+    public TradeDurationStatisticResponse getLatestStatistic() {
+        TradeDurationStatistic stat = tradeDurationStatisticRepository
+                .findTopByOrderByCreatedAtDesc()
+                .orElseThrow(TradeDurationStatisticNotFoundException::new);
+
+        log.info("조회된 최신 거래 소요 시간 통계 - duration: {}초, recordedAt: {}", stat.getDurationSeconds(), stat.getCreatedAt());
+
+        return new TradeDurationStatisticResponse(stat.getDurationSeconds());
+    }
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeDurationStatisticServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeDurationStatisticServiceImpl.java
@@ -7,14 +7,16 @@ import com.ureca.snac.trade.service.interfaces.TradeDurationStatisticService;
 import com.ureca.snac.trade.service.response.TradeDurationStatisticResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
+@Service
 @Transactional
 @RequiredArgsConstructor
 public class TradeDurationStatisticServiceImpl implements TradeDurationStatisticService {
 
-    private TradeDurationStatisticRepository tradeDurationStatisticRepository;
+    private final TradeDurationStatisticRepository tradeDurationStatisticRepository;
 
     @Override
     public TradeDurationStatisticResponse getLatestStatistic() {

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/TradeDurationStatisticService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/TradeDurationStatisticService.java
@@ -1,0 +1,7 @@
+package com.ureca.snac.trade.service.interfaces;
+
+import com.ureca.snac.trade.service.response.TradeDurationStatisticResponse;
+
+public interface TradeDurationStatisticService {
+    TradeDurationStatisticResponse getLatestStatistic();
+}

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeDurationStatisticResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeDurationStatisticResponse.java
@@ -1,0 +1,10 @@
+package com.ureca.snac.trade.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TradeDurationStatisticResponse {
+    private Long durationSeconds;
+}


### PR DESCRIPTION
## 📝 변경 사항

1. 실시간 매칭 거래의 소요 시간을 통계로 저장하고, 최신 통계 데이터를 조회할 수 있는 API를 추가했습니다.

## 🔍 변경 사항 세부 설명

- 실시간 매칭 거래 소요 시간이 집계되어 주기적으로 통계 테이블에 저장됩니다.
- 가장 최근의 거래 소요 시간 통계 데이터를 조회하는 GET API(/api/trade-duration-statistics)를 구현했습니다.

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 