### PR TITLE
[feat] 동일 계정의 소켓 다중 연결 방지 로직 추가

### DIFF
--- a/src/main/java/com/ureca/snac/common/RedisKeyConstants.java
+++ b/src/main/java/com/ureca/snac/common/RedisKeyConstants.java
@@ -10,4 +10,6 @@ public final class RedisKeyConstants {
     public static final String BUYER_FILTER_PREFIX = "buyer_filter:";
     public static final String WS_DISCONNECT_LOCK_PREFIX  = "lock:ws:disconnect:";
     public static final String REDISSON_HOST_PREFIX = "redis://";
+    public static final String WS_CONNECTED_PREFIX = "ws_connected:";
+
 }

--- a/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
+++ b/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
@@ -33,8 +33,7 @@ import java.util.concurrent.TimeUnit;
 import static com.ureca.snac.board.entity.constants.CardCategory.REALTIME_SELL;
 import static com.ureca.snac.board.entity.constants.SellStatus.SELLING;
 import static com.ureca.snac.board.entity.constants.SellStatus.TRADING;
-import static com.ureca.snac.common.RedisKeyConstants.CONNECTED_USERS;
-import static com.ureca.snac.common.RedisKeyConstants.WS_DISCONNECT_LOCK_PREFIX;
+import static com.ureca.snac.common.RedisKeyConstants.*;
 import static com.ureca.snac.trade.entity.CancelReason.BUYER_FORCED_TERMINATION;
 import static com.ureca.snac.trade.entity.CancelReason.SELLER_FORCED_TERMINATION;
 import static com.ureca.snac.trade.entity.TradeStatus.PAYMENT_CONFIRMED;
@@ -88,6 +87,10 @@ public class WebSocketTradeEventListener {
                 return;
             }
 
+            // 0) 연결 해재시 기존 접속자 제거
+            String connectKey = WS_CONNECTED_PREFIX + username;
+            redisTemplate.delete(connectKey);
+
             // 1) 접속자 목록에서 제거
             redisTemplate.opsForSet().remove(CONNECTED_USERS, username);
 
@@ -111,7 +114,7 @@ public class WebSocketTradeEventListener {
             Thread.currentThread().interrupt();
             log.error("락 대기 중 인터럽트 발생: {}", username, e);
         } finally {
-            if (acquired) {
+            if (acquired && lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
         }


### PR DESCRIPTION
## 📝 변경 사항

1. 동일 계정으로 여러 번 소켓 연결 시도를 차단하는 로직 추가

## 🔍 변경 사항 세부 설명

- ChannelInterceptor의 preSend에서 Redis를 이용한 중복 연결 체크 구현
- 이미 연결된 계정으로 또 연결을 시도하면 예외 발생 및 STOMP ERROR 프레임 전송
- disconnect 이벤트 발생 시 단일 연결 키 삭제로 정상 연결 재허용
- 멀티 인스턴스(분산) 환경에서도 안전하게 동작하도록 설계

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 