### PR TITLE
feat: 아직 판매자를 찾지않은 구매글(카드)는 즉시 삭제 가능하도록 변경

### DIFF
--- a/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
@@ -110,7 +110,24 @@ public class TradeCancelServiceImpl implements TradeCancelService {
 
             // 알림 추가
 
-        } else {
+        } else if (trade.getSeller() == null){
+            // 취소 엔티티 저장: ACCEPTED & resolvedAt
+            TradeCancel cancel = TradeCancel.builder()
+                    .trade(trade)
+                    .requester(requester)
+                    .reason(reason)
+                    .status(CancelStatus.ACCEPTED)
+                    .resolvedAt(LocalDateTime.now())
+                    .build();
+            cancelRepo.save(cancel);
+            // 카드 상태 취소
+            card.changeSellStatus(SellStatus.CANCEL);
+            // 거래 취소 및 환불
+            trade.cancel(requester);
+            refundToBuyerAndPublishEvent(trade, card, buyer);
+            // 패널티 x
+        }
+        else {
             // 구매자 => 취소
             TradeCancel cancel = TradeCancel.builder()
                     .trade(trade)


### PR DESCRIPTION
## 📝 변경 사항

1. 기존 구매글에서 결제완료 후 판매자와 거래시작을 안했다면 거래취소 요청시 즉시 거래 취소 되도록 하였습니다.

## 🔍 변경 사항 세부 설명

- 거래 취소 신청 시 즉시 거래 캔슬
- 카드도 캔슬
- 추후 중복코드 개선

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 