### PR TITLE
[feat] 취소 사유기능 수정, 거래 내역 조회 시 취소 요청 상태 조회 추가

### DIFF
--- a/src/main/java/com/ureca/snac/trade/repository/TradeCancelRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeCancelRepository.java
@@ -3,8 +3,11 @@ package com.ureca.snac.trade.repository;
 import com.ureca.snac.trade.entity.CancelStatus;
 import com.ureca.snac.trade.entity.TradeCancel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +18,21 @@ public interface TradeCancelRepository extends JpaRepository<TradeCancel, Long> 
 //    List<TradeCancel> findByStatusAndCreatedAtBefore(CancelStatus status, LocalDateTime before);
 //
     boolean existsByTradeIdAndStatus(Long tradeId, CancelStatus status);
+
+    // 무한 스크롤에 표시용 요약 조회 , 대기중인 취쇼요청만 조회
+    @Query("""
+        select tc.trade.id as tradeId,
+               tc.reason   as reason,
+               tc.createdAt as createdAt
+          from TradeCancel tc
+         where tc.trade.id in :tradeIds
+           and tc.status = com.ureca.snac.trade.entity.CancelStatus.REQUESTED
+    """)
+    List<TradeCancelSummary> findRequestedSummaryByTradeIds(@Param("tradeIds") Collection<Long> tradeIds);
+
+    interface TradeCancelSummary {
+        Long getTradeId();
+        com.ureca.snac.trade.entity.CancelReason getReason();
+        LocalDateTime getCreatedAt();
+    }
 }

--- a/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
@@ -91,8 +91,9 @@ public class TradeCancelServiceImpl implements TradeCancelService {
                 card.changeSellStatus(SellStatus.SELLING);
             }
 
-            // 거래 취소 및 환불
+            // 거래 취소 및 환불 및 취소 이유 입력
             trade.cancel(requester);
+            trade.changeCancelReason(reason);
 
             refundToBuyerAndPublishEvent(trade, card, buyer);
 //            일단 프라비잇으로 환불 로직이랑 이벤트 호출하는거 헬퍼 메소드로 뺏다. 중복 로직이라서 이후의 리팩토링은 자유
@@ -122,8 +123,9 @@ public class TradeCancelServiceImpl implements TradeCancelService {
             cancelRepo.save(cancel);
             // 카드 상태 취소
             card.changeSellStatus(SellStatus.CANCEL);
-            // 거래 취소 및 환불
+            // 거래 취소 및 환불 및 이유 입력
             trade.cancel(requester);
+            trade.changeCancelReason(reason);
             refundToBuyerAndPublishEvent(trade, card, buyer);
             // 패널티 x
         }
@@ -176,6 +178,7 @@ public class TradeCancelServiceImpl implements TradeCancelService {
         // 취소 처리
         cancel.accept();
         trade.cancel(seller); //상태변경까지
+        trade.changeCancelReason(cancel.getReason());//취소 사유
 
 //        위와 마찬가지 이유
         refundToBuyerAndPublishEvent(trade, card, buyer);

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
@@ -6,6 +6,7 @@ import com.ureca.snac.trade.entity.CancelReason;
 import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.entity.TradeStatus;
 import com.ureca.snac.trade.entity.TradeType;
+import com.ureca.snac.trade.repository.TradeCancelRepository;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -32,6 +33,11 @@ public class TradeResponse {
 
     private LocalDateTime createdAt;
 
+    // 대기 중인 취소요청 표시용
+    private boolean cancelRequested; // 취소요청 대기중?
+    private CancelReason cancelRequestReason; // 취소 요청 사유
+
+
     public static TradeResponse from(Trade trade, String username) {
         String phoneToShow = null;
 
@@ -57,7 +63,8 @@ public class TradeResponse {
                 trade.getCancelReason(),
                 trade.getStatus(),
                 trade.getTradeType(),
-                trade.getCreatedAt()
+                trade.getCreatedAt(),
+                false, null
         );
     }
 
@@ -84,7 +91,32 @@ public class TradeResponse {
                 trade.getCancelReason(),
                 trade.getStatus(),
                 trade.getTradeType(),
-                trade.getCreatedAt()
+                trade.getCreatedAt(),
+                false,null
+        );
+    }
+
+    public static TradeResponse from(Trade trade, TradeSide side,
+                                     TradeCancelRepository.TradeCancelSummary cancel) {
+        TradeResponse base = from(trade, side);
+
+        if (cancel == null) return base;
+
+        // base는 불변이므로 cancel 정보가 반영된 새 객체를 만들어 반환
+        return new TradeResponse(
+                base.tradeId,
+                base.buyer,
+                base.seller,
+                base.priceGb,
+                base.dataAmount,
+                base.phone,
+                base.carrier,
+                base.cancelReason,
+                base.status,
+                base.tradeType,
+                base.createdAt,
+                true,
+                cancel.getReason()
         );
     }
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 기존에 거래취소되면 tradeCancel에만 사유가 들어가던걸 trade에도 들어가도록 수정했습니다.
2. 거래 내역 조회 시 취소 요청 상태 확인 할 수 있도록 변경했습니다.

## 🔍 변경 사항 세부 설명

-  단순히 취소 요청 상태를 status로만 처리하기엔 취소요청은 보조 프로세스로 보는게 맞다고 판단했습니다.
- 이미 존재하는 tradeCancel 과의 정합성 문제도 있을거 같아서
- scrollTrades 시 취소요청된 거래를 불린으로 표시하고 취소사유도 함께 나타나도록 했습니다. 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 