### PR TITLE
refactor: 닉네임 변경 쿨다운 로직 및 잠금 해제 시간 계산 추가하여 풀리는 시간을 전송하는 것으로 수정

### DIFF
--- a/src/main/java/com/ureca/snac/member/controller/MemberController.java
+++ b/src/main/java/com/ureca/snac/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import com.ureca.snac.config.RabbitMQConfig;
 import com.ureca.snac.member.dto.request.*;
 import com.ureca.snac.member.dto.response.CountMemberResponse;
 import com.ureca.snac.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.http.ResponseEntity;
@@ -65,7 +66,7 @@ public class MemberController implements MemberControllerSwagger {
     @Override
     public ResponseEntity<ApiResponse<Void>> changePhone(
             CustomUserDetails userDetails,
-            PhoneRequest phoneRequest
+            @Valid PhoneRequest phoneRequest
     ) {
         String changePhone = phoneRequest.getPhone();
         boolean phoneVerified = snsService.isPhoneVerified(changePhone);
@@ -90,8 +91,8 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<ApiResponse<String>> changeNickname(
             CustomUserDetails userDetails,
             NicknameChangeRequest nicknameChangeRequest) {
-        String lastUpdated = memberService.changeNickname(userDetails.getUsername(), nicknameChangeRequest);
-        return ResponseEntity.ok(ApiResponse.of(BaseCode.NICKNAME_CHANGED, lastUpdated));
+        String unlockAt = memberService.changeNickname(userDetails.getUsername(), nicknameChangeRequest);
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.NICKNAME_CHANGED, unlockAt));
     }
 
     //TODO 휴대폰 인증으로 이메일 찾기 (완료, 검증완료)
@@ -104,7 +105,7 @@ public class MemberController implements MemberControllerSwagger {
 
     // 3. 검증 되었는지 확인 후 이메일 찾아주기
     @Override
-    public ResponseEntity<ApiResponse<String>> findEmail(PhoneRequest phoneRequest) {
+    public ResponseEntity<ApiResponse<String>> findEmail(@Valid PhoneRequest phoneRequest) {
         String phone = phoneRequest.getPhone();
         boolean phoneVerified = snsService.isPhoneVerified(phone);
         if (!phoneVerified) {

--- a/src/main/java/com/ureca/snac/member/entity/Member.java
+++ b/src/main/java/com/ureca/snac/member/entity/Member.java
@@ -116,7 +116,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public void changeNicknameTo(String newNickname) {
-        if (nicknameUpdatedAt != null && nicknameUpdatedAt.isAfter(LocalDateTime.now().minusDays(1))) {
+        if (nicknameUpdatedAt != null && nicknameUpdatedAt.isAfter(LocalDateTime.now().minusMinutes(3)/*minusDays(1)*/)) {
             throw new NicknameChangeTooEarlyException();
         }
         this.nickname = newNickname;

--- a/src/main/java/com/ureca/snac/member/entity/Member.java
+++ b/src/main/java/com/ureca/snac/member/entity/Member.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -84,6 +85,7 @@ public class Member extends BaseTimeEntity {
         this.activated = activated;
     }
 
+
     public void addSocialLink(SocialProvider provider, String providerId) {
         SocialLink socialLink = SocialLink.builder()
                 .member(this)
@@ -115,12 +117,22 @@ public class Member extends BaseTimeEntity {
         this.phone = newPhone;
     }
 
+
+    private static final Duration NICKNAME_CHANGE_COOLDOWN = Duration.ofMinutes(3);
+
     public void changeNicknameTo(String newNickname) {
-        if (nicknameUpdatedAt != null && nicknameUpdatedAt.isAfter(LocalDateTime.now().minusMinutes(3)/*minusDays(1)*/)) {
+        if (nicknameUpdatedAt != null && nicknameUpdatedAt.isAfter(LocalDateTime.now().minus(NICKNAME_CHANGE_COOLDOWN))) {
             throw new NicknameChangeTooEarlyException();
         }
         this.nickname = newNickname;
         this.nicknameUpdatedAt = LocalDateTime.now();
+    }
+
+    public LocalDateTime getNextNicknameChangeAllowedAt() {
+        if (nicknameUpdatedAt == null) {
+            return LocalDateTime.now();
+        }
+        return nicknameUpdatedAt.plus(NICKNAME_CHANGE_COOLDOWN);
     }
 
     // 임시 정지

--- a/src/main/java/com/ureca/snac/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ureca/snac/member/service/MemberServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Slf4j
@@ -71,8 +72,8 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new);
         member.changeNicknameTo(nicknameChangeRequest.getNickname());
-        return member.getNicknameUpdatedAt()
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        LocalDateTime unlockAt = member.getNextNicknameChangeAllowedAt();
+        return unlockAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,11 +105,13 @@ spring:
   # JWT 설정
   jwt:
     secret: ${JWT_SECRET_KEY}
-    access-expiration: 900000
+#    access-expiration: 900000
+    access-expiration: 43200000
     #15분
     refresh-expiration: 43200000
     #12시간
-    social-expiration: 60000
+#    social-expiration: 60000
+    social-expiration: 43200000
     #1분
 
   # RabbitMQ 설정


### PR DESCRIPTION
## 📝 변경 사항

1. 클라이언트 측 요청 -> 기존 방식 : 닉네임 변경 시각 / 변경 방식: 닉네임 변경 가능 시각 

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 