### PR TITLE
[feat] 이미지 업로드 및 조회 관련 수정

### DIFF
--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -270,7 +270,7 @@ public enum BaseCode {
     TRADE_CANCEL_REQUESTED("TRADE_CANCEL_REQUESTED_200", HttpStatus.OK, "거래 취소 요청이 등록되었습니다."),
     TRADE_CANCEL_ACCEPTED("TRADE_CANCEL_ACCEPTED_200", HttpStatus.OK, "거래 취소가 승인되었습니다."),
     TRADE_CANCEL_REJECTED("TRADE_CANCEL_REJECTED_200", HttpStatus.OK, "거래 취소 요청이 거절되었습니다."),
-    TRADE_ALREADY_CANCEL_REQUESTED("TRADE_ALREADY_CANCEL_REQUESTED_409", HttpStatus.CONFLICT, "이미 취소 요청이 있습니다."),
+    TRADE_ALREADY_CANCEL_REQUESTED("TRADE_ALREADY_CANCEL_REQUESTED_409", HttpStatus.CONFLICT, "이미 취소 요청 기록이 있습니다."),
     TRADE_CANCEL_NOT_FOUND("TRADE_CANCEL_NOT_FOUND_404", HttpStatus.NOT_FOUND, "취소 요청 정보를 찾을 수 없습니다."),
 
     // 스케줄러 자동 처리
@@ -327,7 +327,8 @@ public enum BaseCode {
     S3_UPLOAD_FAILED("S3_UPLOAD_FAILED_500", HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드에 실패했습니다."),
     S3_DELETE_FAILED("S3_DELETE_FAILED_500", HttpStatus.INTERNAL_SERVER_ERROR, "S3 삭제에 실패했습니다"),
     ATTACHMENT_UPLOAD_SUCCESS("ATTACHMENT_UPLOAD_SUCCESS_201", HttpStatus.CREATED, "이미지가 성공적으로 업로드되었습니다."),
-    ATTACHMENT_PRESIGNED_URL_ISSUED("ATTACHMENT_PRESIGNED_URL_ISSUED_200", HttpStatus.OK, "첨부 이미지에 대한 접근 URL이 발급되었습니다.");
+    ATTACHMENT_PRESIGNED_URL_ISSUED("ATTACHMENT_PRESIGNED_URL_ISSUED_200", HttpStatus.OK, "첨부 이미지에 대한 접근 URL이 발급되었습니다."),
+    ATTACHMENT_PRESIGNED_UPLOAD_URL_ISSUED("ATTACHMENT_PRESIGNED__UPLOAD_URL_ISSUED_200", HttpStatus.OK, "s3 업로드를 위한 URL이 발급되었습니다.");
     private final String code;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ureca/snac/trade/controller/AttachmentController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/AttachmentController.java
@@ -13,11 +13,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 @RestController
-@RequestMapping("/api/trades")
+@RequestMapping
 @RequiredArgsConstructor
 public class AttachmentController {
 
@@ -25,7 +26,7 @@ public class AttachmentController {
     private final S3Uploader s3Uploader;
 
     // 거래 이미지 Presigned URL 발급
-    @GetMapping("/{tradeId}/attachment-url")
+    @GetMapping("/api/trades/{tradeId}/attachment-url")
     public ResponseEntity<ApiResponse<String>> getPresignedUrl(
             @PathVariable Long tradeId,
             @AuthenticationPrincipal UserDetails userDetails) {
@@ -36,7 +37,8 @@ public class AttachmentController {
     }
 
     // 신고할때 이미지 올리기 (백엔드 거쳐서 업로드)
-    @PostMapping(value = "/dispute/attachment",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // 안쓸거
+    @PostMapping(value = "/api/trades/dispute/attachment",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<?>> upload(
             @RequestPart("files") List<MultipartFile> files) {
 
@@ -50,11 +52,16 @@ public class AttachmentController {
     // 프론트에서 바로 업로드하는 뉴 방법
     // 서버는 presigned url 을 만들어주기만 하고 실제 업로드는 s3가
     // s3에 직접 put 방식으로
-    @PostMapping("/dispute/attachment-url")
-    public ResponseEntity<ApiResponse<String>> getDisputePresignedUrl(
+    @PostMapping("/api/attachments/upload-url") // 업로드용 url 얻는 api
+    public ResponseEntity<ApiResponse<Map<String, String>>> getDisputePresignedUrl(
             @RequestParam("filename") String filename) {
         String s3Key = s3Uploader.buildKey(filename, "disputes/attachments");
         String url = s3Uploader.generatePresignedPutUrl(s3Key); // PUT presigned url
-        return ResponseEntity.ok(ApiResponse.of(BaseCode.ATTACHMENT_PRESIGNED_URL_ISSUED, url));
+        Map<String, String> data = Map.of(
+                "s3Key", s3Key,
+                "uploadUrl", url
+        );
+
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.ATTACHMENT_PRESIGNED_UPLOAD_URL_ISSUED, data));
     }
 }

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
@@ -4,12 +4,15 @@ import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
+import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.entity.Dispute;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
 import com.ureca.snac.trade.service.interfaces.DisputeAdminService;
 import com.ureca.snac.trade.service.interfaces.DisputeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,7 +24,7 @@ import static com.ureca.snac.common.BaseCode.*;
 
 
 @RestController
-@RequestMapping("/admin/disputes")
+@RequestMapping("/api/admin/disputes")
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ADMIN')")
 public class DisputeAdminController {
@@ -68,8 +71,8 @@ public class DisputeAdminController {
             @RequestParam(defaultValue="0") int page,
             @RequestParam(defaultValue="20") int size) {
 
-        var cond = new DisputeSearchCond(DisputeStatus.IN_PROGRESS, null, null);
-        var data = disputeAdminService.list(cond, PageRequest.of(page,size));
+        DisputeSearchCond cond = new DisputeSearchCond(DisputeStatus.IN_PROGRESS, null, null);
+        Page<DisputeDetailResponse> data = disputeAdminService.list(cond, PageRequest.of(page,size));
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_DETAIL_SUCCESS, data));
     }
 

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeController.java
@@ -2,16 +2,18 @@ package com.ureca.snac.trade.controller;
 
 import com.ureca.snac.common.ApiResponse;
 import com.ureca.snac.common.BaseCode;
-import com.ureca.snac.trade.dto.dispute.DisputeCreateRequest;
-import com.ureca.snac.trade.dto.dispute.QnaCreateRequest;
+import com.ureca.snac.trade.dto.dispute.*;
 import com.ureca.snac.trade.service.interfaces.DisputeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -55,7 +57,7 @@ public class DisputeController {
             @AuthenticationPrincipal UserDetails me) {
 
         PageRequest pr = PageRequest.of(page, size);
-        var data = disputeService.listMyDisputes(me.getUsername(), pr);
+        Page<MyDisputeListItemDto> data = disputeService.listMyDisputes(me.getUsername(), pr);
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_MY_LIST_SUCCESS, data));
     }
 
@@ -67,7 +69,7 @@ public class DisputeController {
             @AuthenticationPrincipal UserDetails me) {
 
         PageRequest pr = PageRequest.of(page, size);
-        var data = disputeService.listDisputesAgainstMe(me.getUsername(), pr);
+        Page<ReceivedDisputeListItemDto> data = disputeService.listDisputesAgainstMe(me.getUsername(), pr);
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_RECEIVED_LIST_SUCCESS, data));
     }
 
@@ -84,4 +86,5 @@ public class DisputeController {
         );
         return ResponseEntity.ok(ApiResponse.of(BaseCode.QNA_CREATE_SUCCESS, id));
     }
+
 }

--- a/src/main/java/com/ureca/snac/trade/service/DisputeServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeServiceImpl.java
@@ -109,17 +109,24 @@ public class DisputeServiceImpl implements DisputeService {
     public Page<MyDisputeListItemDto> listMyDisputes(String email, Pageable pageable) {
         Member me = findMember(email);
         return disputeRepository.findByReporterOrderByCreatedAtDesc(me, pageable)
-                .map(dispute -> new MyDisputeListItemDto(
-                        dispute.getId(),
-                        dispute.getStatus(),
-                        dispute.getType(),
-                        dispute.getTitle(),
-                        dispute.getDescription(),
-                        dispute.getCreatedAt(),
-                        dispute.getAnswerAt(),
-                        toTradeSummary(dispute.getTrade(), me)
-                ));
+                .map(dispute -> {
+                    TradeSummaryDto summary = null;
+                    if (dispute.getTrade() != null) {
+                        summary = toTradeSummary(dispute.getTrade(), me);
+                    }
+                    return new MyDisputeListItemDto(
+                            dispute.getId(),
+                            dispute.getStatus(),
+                            dispute.getType(),
+                            dispute.getTitle(),
+                            dispute.getDescription(),
+                            dispute.getCreatedAt(),
+                            dispute.getAnswerAt(),
+                            summary
+                    );
+                });
     }
+
     // 신고받은 목록
     public Page<ReceivedDisputeListItemDto> listDisputesAgainstMe(String email, Pageable pageable) {
         Member me = findMember(email);


### PR DESCRIPTION
## 📝 변경 사항

- 이미지 첨부 api 앤드포인트 개선
- 업로드 용 url api 에서 리턴값에 s3key 포함하도록 수정
- 문의 조회 시 거래아이디가 없으므로 null 로 들어가도록 처리

- 기타 사소한 수정
 반환값 명시
 basecode 명시

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)
<img width="652" height="550" alt="image" src="https://github.com/user-attachments/assets/ca98328e-d3e2-4244-ad99-da2872ef8fa6" />
<img width="542" height="514" alt="image" src="https://github.com/user-attachments/assets/b2ea6ae3-ef7f-450a-ba08-772ce57aa845" />

- 