### PR TITLE
[feat] 신고(문의) 사용자 api 스웨거 작성,  카드캔슬처리 대신 카드삭제 처리

### DIFF
--- a/src/main/java/com/ureca/snac/trade/controller/DisputeController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class DisputeController {
+public class DisputeController implements DisputeControllerSwagger{
 
     private final DisputeService disputeService;
 

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeControllerSwagger.java
@@ -1,0 +1,84 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.swagger.annotation.error.ErrorCode400;
+import com.ureca.snac.swagger.annotation.error.ErrorCode401;
+import com.ureca.snac.swagger.annotation.error.ErrorCode403;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiCreatedResponse;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import com.ureca.snac.trade.dto.dispute.DisputeCreateRequest;
+import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.dto.dispute.MyDisputeListItemDto;
+import com.ureca.snac.trade.dto.dispute.QnaCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "신고/문의 관리", description = "거래 신고 및 QnA(문의) 관련 기능")
+@SecurityRequirement(name = "Authorization")
+@RequestMapping("/api")
+public interface DisputeControllerSwagger {
+
+    @Operation(
+            summary = "거래 신고(문의) 등록",
+            description = "특정 거래에 대한 신고를 등록합니다. 첨부파일은 미리 presigned url로 S3에 업로드 후 키만 전달합니다."
+    )
+    @ApiCreatedResponse(description = "신고 등록 성공")
+    @ErrorCode400(description = "입력값이 올바르지 않음")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @ErrorCode403(description = "해당 거래에 대한 권한 없음")
+    @PostMapping("/trades/{tradeId}/disputes")
+    ResponseEntity<ApiResponse<?>> createDispute(
+            @PathVariable Long tradeId,
+            @Valid @RequestBody DisputeCreateRequest disputeCreateRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+
+    @Operation(
+            summary = "신고(문의) 상세 조회",
+            description = "내가 신고한 거래 또는 내 QnA(문의) 상세 내용을 확인합니다. 첨부이미지는 presigned url로 반환됩니다."
+    )
+    @ApiSuccessResponse(description = "상세 조회 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @ErrorCode403(description = "접근 권한 없음")
+    @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
+    @GetMapping("/disputes/{id}")
+    ResponseEntity<ApiResponse<?>> detailDispute(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+
+    @Operation(
+            summary = "내 신고/문의 내역 조회",
+            description = "내가 등록한 신고 및 QnA(문의) 목록을 조회합니다. 페이징 지원."
+    )
+    @ApiSuccessResponse(description = "목록 조회 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @GetMapping("/disputes/mine")
+    ResponseEntity<ApiResponse<?>> myDisputes(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+
+    @Operation(
+            summary = "QnA(일반 문의) 등록",
+            description = "거래와 무관한 일반 문의(QnA)를 등록합니다. 첨부파일은 미리 presigned url로 S3에 업로드 후 키만 전달합니다."
+    )
+    @ApiCreatedResponse(description = "QnA 등록 성공")
+    @ErrorCode400(description = "입력값이 올바르지 않음")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @PostMapping("/qna")
+    ResponseEntity<ApiResponse<?>> createQna(
+            @Valid @RequestBody QnaCreateRequest qnaCreateRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+}

--- a/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
@@ -91,7 +91,9 @@ public class TradeCancelServiceImpl implements TradeCancelService {
             // 카드 상태 처리
             // 지금 판매자가 취소 요청 상태인데 판매글이면 삭제 처리 / 구매글이면 다시 구매중으로
             if(card.getCardCategory() == CardCategory.SELL){
-                card.changeSellStatus(SellStatus.CANCEL);
+//                card.changeSellStatus(SellStatus.CANCEL);
+                // 카드 삭제 처리
+                cardRepo.deleteById(card.getId());
             } else if (card.getCardCategory() == CardCategory.BUY){
                 card.changeSellStatus(SellStatus.SELLING);
             }
@@ -126,8 +128,12 @@ public class TradeCancelServiceImpl implements TradeCancelService {
                     .resolvedAt(LocalDateTime.now())
                     .build();
             cancelRepo.save(cancel);
+
             // 카드 상태 취소
-            card.changeSellStatus(SellStatus.CANCEL);
+//            card.changeSellStatus(SellStatus.CANCEL);
+            // 카드 삭제 처리
+            cardRepo.deleteById(card.getId());
+
             // 거래 취소 및 환불 및 이유 입력
             trade.cancel(requester);
             trade.changeCancelReason(reason);
@@ -177,7 +183,9 @@ public class TradeCancelServiceImpl implements TradeCancelService {
         // 카드 상태 처리
         // 지금 구매자가 취소 요청 상태인데 구매글이면 삭제 처리 / 판매글이면 다시 판매중으로
         if(card.getCardCategory() == CardCategory.BUY){
-            card.changeSellStatus(SellStatus.CANCEL);
+//            card.changeSellStatus(SellStatus.CANCEL);
+            // 카드 삭제 처리
+            cardRepo.deleteById(card.getId());
         } else if (card.getCardCategory() == CardCategory.SELL){
             card.changeSellStatus(SellStatus.SELLING);
         }


### PR DESCRIPTION
## 📝 변경 사항

1. 사용자의 신고(문의) api 에 대한 스웨거 작성했습니다.
2. 기존에 본인 카드를 본인이 취소하면 카드를 캔슬 처리했는데 삭제되도록 변경했습니다.

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 
<img width="626" height="356" alt="image" src="https://github.com/user-attachments/assets/7c134061-4449-4092-932a-a01916231027" />
