### PR TITLE
[hotfix] add TradeResponse field (단골 여부, id, 닉네임)

### DIFF
--- a/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/ureca/snac/favorite/repository/FavoriteRepository.java
@@ -13,13 +13,13 @@ import java.util.Set;
 public interface FavoriteRepository extends JpaRepository<Favorite, Long>,
         FavoriteRepositoryCustom {
     /**
-     * 단골관계 있는지 여부 확인
+     * 특정 단골 관계 존재여부 ID 기반 조회
      *
-     * @param fromMember 단골 등록 하는 사람
-     * @param toMember   등록 당하는 사람
-     * @return 존재 여부
+     * @param fromMemberId 단골을 동록할 회원 ID
+     * @param toMemberId   단골로 등록될 회원 ID
+     * @return 관계 존재 여부
      */
-    boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
+    boolean existsByFromMemberIdAndToMemberId(Long fromMemberId, Long toMemberId);
 
     /**
      * 특정 단골 관계 조회
@@ -39,9 +39,17 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long>,
      */
     Long countByFromMember(Member fromMember);
 
+    /**
+     * 특정 회원이 주어진 ID 목록에서 단골로 추가한 회원의 ID 만 반환
+     * N+1대비
+     *
+     * @param fromMember  단골 목록의 기준이 되는 회원
+     * @param toMemberIds 확인할 상대방 회원 ID 목록
+     * @return 주어진 ID 목록중 단골 회원 ID 만 담은 SET
+     */
     @Query("""
-            select f.toMember.id from Favorite f where f.fromMember = :fromMember and 
-            f.toMember.id in :toMemberIds
+            select f.toMember.id from Favorite f where f.fromMember = :fromMember
+            and f.toMember.id in :toMemberIds
             """)
     Set<Long> findFavoriteToMemberIdsByFromMember(@Param("fromMember") Member fromMember,
                                                   @Param("toMemberIds") List<Long> toMemberIds);

--- a/src/main/java/com/ureca/snac/favorite/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/ureca/snac/favorite/service/FavoriteServiceImpl.java
@@ -42,7 +42,7 @@ public class FavoriteServiceImpl implements FavoriteService {
 
         Member toMember = findMemberById(toMemberId);
 
-        if (favoriteRepository.existsByFromMemberAndToMember(fromMember, toMember)) {
+        if (favoriteRepository.existsByFromMemberIdAndToMemberId(fromMember.getId(), toMember.getId())) {
             throw new AlreadyFavoriteMember();
         }
 
@@ -109,7 +109,7 @@ public class FavoriteServiceImpl implements FavoriteService {
         Member fromMember = findMemberByEmail(fromUserEmail);
         Member toMember = findMemberById(toMemberId);
 
-        boolean isFavorite = favoriteRepository.existsByFromMemberAndToMember(fromMember, toMember);
+        boolean isFavorite = favoriteRepository.existsByFromMemberIdAndToMemberId(fromMember.getId(), toMember.getId());
 
         log.info("[단골 여부 확인] 요청자 : {}, 상대방 : {}, 여부 : {}",
                 fromUserEmail, toMemberId, isFavorite);

--- a/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
+++ b/src/main/java/com/ureca/snac/trade/service/response/TradeResponse.java
@@ -1,7 +1,6 @@
 package com.ureca.snac.trade.service.response;
 
 import com.ureca.snac.board.entity.constants.Carrier;
-import com.ureca.snac.trade.dto.TradeSide;
 import com.ureca.snac.trade.entity.*;
 import com.ureca.snac.trade.repository.TradeCancelRepository;
 import lombok.Getter;
@@ -10,36 +9,38 @@ import java.time.LocalDateTime;
 
 @Getter
 public class TradeResponse {
-    private Long tradeId;
+    private final Long tradeId;
 
     // 판매자 OR 구매자
-    private String buyer;
-    private String seller;
+    private final String buyer;
+    private final String seller;
 
-    private Integer priceGb;
-    private Integer dataAmount;
-    private String phone;
+    private final Integer priceGb;
+    private final Integer dataAmount;
+    private final String phone;
 
-    private Carrier carrier;
-    private CancelReason cancelReason;
-    private TradeStatus status;
-    private TradeType tradeType;
+    private final Carrier carrier;
+    private final CancelReason cancelReason;
+    private final TradeStatus status;
+    private final TradeType tradeType;
 
-    private LocalDateTime createdAt;
+    private final LocalDateTime createdAt;
 
     // 대기 중인 취소요청 표시용
-    private boolean cancelRequested; // 취소요청 대기중?
-    private CancelReason cancelRequestReason; // 취소 요청 사유
-    private CancelStatus cancelRequestStatus;
+    private final boolean cancelRequested; // 취소요청 대기중?
+    private final CancelReason cancelRequestReason; // 취소 요청 사유
+    private final CancelStatus cancelRequestStatus;
 
-    private boolean isPartnerFavorite; // 거래 상대방이 나랑 단골인지?
+    private final Long partnerId; // 상대방 ID
+    private final String partnerNickname; // 상대방 닉네임
+    private final boolean isPartnerFavorite; // 거래 상대방이 나랑 단골인지?
 
     private TradeResponse(Long tradeId, String buyer, String seller, Integer priceGb,
                           Integer dataAmount, String phone, Carrier carrier, CancelReason cancelReason,
                           TradeStatus status, TradeType tradeType, LocalDateTime createdAt,
                           boolean cancelRequested, CancelReason cancelRequestReason,
                           CancelStatus cancelRequestStatus,
-                          boolean isPartnerFavorite) {
+                          Long partnerId, String partnerNickname, boolean isPartnerFavorite) {
         this.tradeId = tradeId;
         this.buyer = buyer;
         this.seller = seller;
@@ -54,17 +55,22 @@ public class TradeResponse {
         this.cancelRequested = cancelRequested;
         this.cancelRequestReason = cancelRequestReason;
         this.cancelRequestStatus = cancelRequestStatus;
+        this.partnerId = partnerId;
+        this.partnerNickname = partnerNickname;
         this.isPartnerFavorite = isPartnerFavorite;
     }
 
     public static TradeResponse from(
             Trade trade, String username, boolean isPartnerFavorite,
-            TradeCancelRepository.TradeCancelSummary cancel) {
+            TradeCancelRepository.TradeCancelSummary cancel, Long partnerId,
+            String partnerNickname) {
+
         String phoneToShow = null;
 
         if (username.equals(trade.getBuyer().getEmail())) {
             phoneToShow = trade.getPhone();
-        } else if (username.equals(trade.getSeller().getEmail()) &&
+        } else if (trade.getSeller() != null &&
+                username.equals(trade.getSeller().getEmail()) &&
                 trade.getStatus() == TradeStatus.PAYMENT_CONFIRMED) {
             phoneToShow = trade.getPhone();
         }
@@ -88,105 +94,13 @@ public class TradeResponse {
                 isCancelRequest,
                 reason,
                 status,
+                partnerId,
+                partnerNickname,
                 isPartnerFavorite
         );
     }
 
     public static TradeResponse from(Trade trade, String username) {
-        return from(trade, username, false, null);
+        return from(trade, username, false, null, null, null);
     }
-
-    public static TradeResponse from(Trade trade, TradeSide tradeSide) {
-        String tempUsernameForPhone = (tradeSide == TradeSide.BUY) ?
-                trade.getBuyer().getEmail() : trade.getSeller().getEmail();
-        return from(trade, tempUsernameForPhone, false, null);
-    }
-
-    public static TradeResponse from(Trade trade, TradeSide tradeSide,
-                                     TradeCancelRepository.TradeCancelSummary cancel) {
-        String tempUsernameForSummary = (tradeSide == TradeSide.BUY) ?
-                trade.getBuyer().getEmail() : trade.getSeller().getEmail();
-        return from(trade, tempUsernameForSummary, false, cancel);
-    }
-//    public static TradeResponse from(Trade trade, String username) {
-//        String phoneToShow = null;
-//
-//        // 구매자 측면에서는 언제나 본인 번호를 보여주고,
-//        if (username.equals(trade.getBuyer().getEmail())) {
-//            phoneToShow = trade.getPhone();
-//        }
-//        // 판매자 측면에서는 결제 확정 단계(PAYMENT_CONFIRMED)일 때만 보여줌
-//        else if (username.equals(trade.getSeller().getEmail()) && trade.getStatus() == TradeStatus.PAYMENT_CONFIRMED) {
-//            phoneToShow = trade.getPhone();
-//        }
-//
-//        return new TradeResponse(
-//                trade.getId(),
-//
-//                trade.getBuyer().getEmail(),
-//                (trade.getSeller() != null) ? trade.getSeller().getEmail() : "",
-//
-//                trade.getPriceGb(),
-//                trade.getDataAmount(),
-//                phoneToShow,
-//                trade.getCarrier(),
-//                trade.getCancelReason(),
-//                trade.getStatus(),
-//                trade.getTradeType(),
-//                trade.getCreatedAt(),
-//                false, null
-//        );
-//    }
-//
-//    public static TradeResponse from(Trade trade, TradeSide side) {
-//        String phoneToShow = null;
-//
-//        // 구매자 측면에서는 언제나 본인 번호를 보여주고,
-//        if (side == TradeSide.BUY) {
-//            phoneToShow = trade.getPhone();
-//        }
-//        // 판매자 측면에서는 결제 확정 단계(PAYMENT_CONFIRMED)일 때만 보여줌
-//        else if (side == TradeSide.SELL && trade.getStatus() == TradeStatus.PAYMENT_CONFIRMED) {
-//            phoneToShow = trade.getPhone();
-//        }
-//
-//        return new TradeResponse(
-//                trade.getId(),
-//                trade.getBuyer().getEmail(),
-//                (trade.getSeller() != null) ? trade.getSeller().getEmail() : "",
-//                trade.getPriceGb(),
-//                trade.getDataAmount(),
-//                phoneToShow,
-//                trade.getCarrier(),
-//                trade.getCancelReason(),
-//                trade.getStatus(),
-//                trade.getTradeType(),
-//                trade.getCreatedAt(),
-//                false, null
-//        );
-//    }
-//
-//    public static TradeResponse from(Trade trade, TradeSide side,
-//                                     TradeCancelRepository.TradeCancelSummary cancel) {
-//        TradeResponse base = from(trade, side);
-//
-//        if (cancel == null) return base;
-//
-//        // base는 불변이므로 cancel 정보가 반영된 새 객체를 만들어 반환
-//        return new TradeResponse(
-//                base.tradeId,
-//                base.buyer,
-//                base.seller,
-//                base.priceGb,
-//                base.dataAmount,
-//                base.phone,
-//                base.carrier,
-//                base.cancelReason,
-//                base.status,
-//                base.tradeType,
-//                base.createdAt,
-//                true,
-//                cancel.getReason()
-//        );
-//    }
 }


### PR DESCRIPTION
## 📝 변경 사항

1. Trade scroll 을 통해 내려오는 응답 필드 추가 ( 닉네임, 단골여부, 상대방 id)
2. 조회 엔티티 -> 필드로 변경 (쓸데없는 값필요없으니)

## 🔍 변경 사항 세부 설명

- existsByFromMemberIdAndToMemberId 엔티티 -> id 필드
