### PR TITLE
[feat] 신고(문의) 관리 기능 스웨거 작성, 관리자 기능 수정 및 dispute 카테고리 필드추가

### DIFF
--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
@@ -44,7 +44,7 @@ public class DisputeAdminController {
 
         BaseCode baseCode = switch (disputeAnswerRequest.getResult()) {
             case NEED_MORE -> DISPUTE_NEED_MORE;
-            case REJECTED  -> DISPUTE_REJECTED_SUCCESS;
+//            case REJECTED  -> DISPUTE_REJECTED_SUCCESS;
             default        -> DISPUTE_ANSWERED_SUCCESS;
         };
 
@@ -60,19 +60,19 @@ public class DisputeAdminController {
             @RequestParam(defaultValue="0") int page,
             @RequestParam(defaultValue="20") int size) {
 
-        var cond = new DisputeSearchCond(status, type, reporter);
-        var data = disputeAdminService.list(cond, PageRequest.of(page,size));
+        DisputeSearchCond cond = new DisputeSearchCond(status, type, reporter);
+        Page<DisputeDetailResponse> data = disputeAdminService.searchList(cond, PageRequest.of(page,size));
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_DETAIL_SUCCESS, data));
     }
 
-    // 처리 대기 신고
+    // 처리 대기 신고(문의)
     @GetMapping("/pending")
     public ResponseEntity<ApiResponse<?>> pending(
             @RequestParam(defaultValue="0") int page,
             @RequestParam(defaultValue="20") int size) {
 
         DisputeSearchCond cond = new DisputeSearchCond(DisputeStatus.IN_PROGRESS, null, null);
-        Page<DisputeDetailResponse> data = disputeAdminService.list(cond, PageRequest.of(page,size));
+        Page<DisputeDetailResponse> data = disputeAdminService.searchList(cond, PageRequest.of(page,size));
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_DETAIL_SUCCESS, data));
     }
 
@@ -114,7 +114,7 @@ public class DisputeAdminController {
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails admin) {
 
-        boolean restored = disputeAdminService.finalizeIfNoActive(id, admin.getUsername());
+        boolean restored = disputeAdminService.restoreIfNoActive(id, admin.getUsername());
         BaseCode code = restored ? BaseCode.DISPUTE_FINALIZE_RESTORED
                 : BaseCode.DISPUTE_FINALIZE_SKIPPED;
         return ResponseEntity.ok(ApiResponse.ok(code));

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
@@ -6,6 +6,7 @@ import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
 import com.ureca.snac.trade.entity.Dispute;
+import com.ureca.snac.trade.entity.DisputeCategory;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
 import com.ureca.snac.trade.service.interfaces.DisputeAdminService;
@@ -27,7 +28,7 @@ import static com.ureca.snac.common.BaseCode.*;
 @RequestMapping("/api/admin/disputes")
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ADMIN')")
-public class DisputeAdminController {
+public class DisputeAdminController implements  DisputeAdminControllerSwagger{
 
     private final DisputeAdminService disputeAdminService;
     private final DisputeService disputeService;
@@ -53,32 +54,33 @@ public class DisputeAdminController {
 
     // 전체 검색
     @GetMapping
-    public ResponseEntity<ApiResponse<?>> search(
+    public ResponseEntity<ApiResponse<Page<DisputeDetailResponse>>> search(
             @RequestParam(required=false) DisputeStatus status,
             @RequestParam(required=false) DisputeType type,
             @RequestParam(required=false) String reporter,
+            @RequestParam(required=false) DisputeCategory category,
             @RequestParam(defaultValue="0") int page,
             @RequestParam(defaultValue="20") int size) {
 
-        DisputeSearchCond cond = new DisputeSearchCond(status, type, reporter);
+        DisputeSearchCond cond = new DisputeSearchCond(status, type, reporter, category);
         Page<DisputeDetailResponse> data = disputeAdminService.searchList(cond, PageRequest.of(page,size));
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_DETAIL_SUCCESS, data));
     }
 
     // 처리 대기 신고(문의)
     @GetMapping("/pending")
-    public ResponseEntity<ApiResponse<?>> pending(
+    public ResponseEntity<ApiResponse<Page<DisputeDetailResponse>>> pending(
             @RequestParam(defaultValue="0") int page,
             @RequestParam(defaultValue="20") int size) {
 
-        DisputeSearchCond cond = new DisputeSearchCond(DisputeStatus.IN_PROGRESS, null, null);
+        DisputeSearchCond cond = new DisputeSearchCond(DisputeStatus.IN_PROGRESS, null, null,null);
         Page<DisputeDetailResponse> data = disputeAdminService.searchList(cond, PageRequest.of(page,size));
         return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_DETAIL_SUCCESS, data));
     }
 
     // 상세
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<?>> detailDispute(
+    public ResponseEntity<ApiResponse<DisputeDetailResponse>> detailDispute(
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails userDetails) {
 

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminControllerSwagger.java
@@ -11,6 +11,7 @@ import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
+import com.ureca.snac.trade.entity.DisputeCategory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,95 +29,96 @@ import jakarta.validation.Valid;
 public interface DisputeAdminControllerSwagger {
 
     @Operation(
-        summary = "신고/문의 답변 처리",
-        description = "신고/문의에 대해 답변 및 상태를 변경합니다. (자료 추가 요청, 기각, 답변완료)"
+            summary = "신고/문의 답변 처리",
+            description = "신고/문의에 대해 답변(ANSWERED) 또는 자료 추가 요청(NEED_MORE)으로 상태를 변경합니다. 후처리(환불/복구/패널티)는 별도 액션에서 실행하세요."
     )
     @ApiSuccessResponse(description = "답변 처리 성공")
     @ErrorCode400(description = "잘못된 입력 또는 상태")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @PatchMapping("/{id}/resolve")
     ResponseEntity<ApiResponse<?>> answer(
-        @PathVariable Long id,
-        @Valid @RequestBody DisputeAnswerRequest disputeAnswerRequest,
-        @AuthenticationPrincipal UserDetails userDetails
+            @PathVariable Long id,
+            @Valid @RequestBody DisputeAnswerRequest disputeAnswerRequest,
+            @AuthenticationPrincipal UserDetails userDetails
     );
 
     @Operation(
-        summary = "신고/문의 전체 검색",
-        description = "상태, 유형, 신고자 등 조건별로 신고/문의 목록을 조회합니다. (페이징 지원, 관리자만 접근 가능)"
+            summary = "신고/문의 전체 검색",
+            description = "상태, 유형, 카테고리, 신고자 등 조건별로 신고/문의 목록을 조회합니다. (페이징 지원, 관리자만 접근 가능)"
     )
     @ApiSuccessResponse(description = "목록 조회 성공")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @GetMapping
     ResponseEntity<ApiResponse<Page<DisputeDetailResponse>>> search(
-        @RequestParam(required=false) DisputeStatus status,
-        @RequestParam(required=false) DisputeType type,
-        @RequestParam(required=false) String reporter,
-        @RequestParam(defaultValue="0") int page,
-        @RequestParam(defaultValue="20") int size
+            @RequestParam(required=false) DisputeStatus status,
+            @RequestParam(required=false) DisputeType type,
+            @RequestParam(required=false) String reporter,
+            @RequestParam(required=false) DisputeCategory category,  // 카테고리 필터 추가!
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="20") int size
     );
 
     @Operation(
-        summary = "처리 대기 신고/문의 목록",
-        description = "IN_PROGRESS 상태(진행 중) 신고/문의만 페이징 조회합니다."
+            summary = "처리 대기 신고/문의 목록",
+            description = "IN_PROGRESS 상태(진행 중) 신고/문의만 페이징 조회합니다."
     )
     @ApiSuccessResponse(description = "목록 조회 성공")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @GetMapping("/pending")
     ResponseEntity<ApiResponse<Page<DisputeDetailResponse>>> pending(
-        @RequestParam(defaultValue="0") int page,
-        @RequestParam(defaultValue="20") int size
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="20") int size
     );
 
     @Operation(
-        summary = "신고/문의 상세 조회",
-        description = "특정 신고/문의의 상세 정보를 확인합니다."
+            summary = "신고/문의 상세 조회",
+            description = "특정 신고/문의의 상세 정보를 확인합니다."
     )
     @ApiSuccessResponse(description = "상세 조회 성공")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
     @GetMapping("/{id}")
     ResponseEntity<ApiResponse<DisputeDetailResponse>> detailDispute(
-        @PathVariable Long id,
-        @AuthenticationPrincipal UserDetails userDetails
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails
     );
 
     @Operation(
-        summary = "신고/문의 환불 및 거래취소",
-        description = "관리자가 답변 완료(ANSWERED) 상태의 신고/문의 건에 대해 환불 및 거래취소를 처리합니다."
+            summary = "신고/문의 환불 및 거래취소",
+            description = "관리자가 답변 완료(ANSWERED) 상태의 신고/문의 건에 대해 환불 및 거래취소를 처리합니다."
     )
     @ApiSuccessResponse(description = "환불 및 거래취소 성공")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
     @PostMapping("/{id}/refund-and-cancel")
     ResponseEntity<ApiResponse<Void>> refundAndCancel(
-        @PathVariable Long id,
-        @AuthenticationPrincipal UserDetails admin
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails admin
     );
 
     @Operation(
-        summary = "판매자 패널티 부여",
-        description = "관리자가 신고/문의에 대해 판매자에게 패널티를 부여합니다."
+            summary = "판매자 패널티 부여",
+            description = "관리자가 신고/문의에 대해 판매자에게 패널티를 부여합니다."
     )
     @ApiSuccessResponse(description = "패널티 부여 성공")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
     @PostMapping("/{id}/penalty-seller")
     ResponseEntity<ApiResponse<Void>> penaltySeller(
-        @PathVariable Long id,
-        @AuthenticationPrincipal UserDetails admin
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails admin
     );
 
     @Operation(
-        summary = "신고/문의 복구 시도",
-        description = "해당 거래에 활성(IN_PROGRESS/NEED_MORE) 신고가 0개면 거래를 원상복구합니다."
+            summary = "신고/문의 복구 시도",
+            description = "해당 거래에 활성(IN_PROGRESS/NEED_MORE) 신고가 0개면 거래를 원상복구합니다."
     )
     @ApiSuccessResponse(description = "복구 처리 결과 반환")
     @ErrorCode401(description = "인증되지 않은 사용자")
     @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
     @PostMapping("/{id}/finalize")
     ResponseEntity<ApiResponse<Void>> finalizeIfNoActive(
-        @PathVariable Long id,
-        @AuthenticationPrincipal UserDetails admin
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails admin
     );
 }

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminControllerSwagger.java
@@ -1,0 +1,122 @@
+package com.ureca.snac.trade.controller;
+
+import com.ureca.snac.common.ApiResponse;
+import com.ureca.snac.swagger.annotation.error.ErrorCode400;
+import com.ureca.snac.swagger.annotation.error.ErrorCode401;
+import com.ureca.snac.swagger.annotation.error.ErrorCode403;
+import com.ureca.snac.swagger.annotation.error.ErrorCode404;
+import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
+import com.ureca.snac.trade.dto.DisputeSearchCond;
+import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
+import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.entity.DisputeStatus;
+import com.ureca.snac.trade.entity.DisputeType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "신고/문의 어드민 관리", description = "관리자 전용 신고/문의 답변, 환불, 패널티, 복구 기능")
+@SecurityRequirement(name = "Authorization")
+@RequestMapping("/api/admin/disputes")
+public interface DisputeAdminControllerSwagger {
+
+    @Operation(
+        summary = "신고/문의 답변 처리",
+        description = "신고/문의에 대해 답변 및 상태를 변경합니다. (자료 추가 요청, 기각, 답변완료)"
+    )
+    @ApiSuccessResponse(description = "답변 처리 성공")
+    @ErrorCode400(description = "잘못된 입력 또는 상태")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @PatchMapping("/{id}/resolve")
+    ResponseEntity<ApiResponse<?>> answer(
+        @PathVariable Long id,
+        @Valid @RequestBody DisputeAnswerRequest disputeAnswerRequest,
+        @AuthenticationPrincipal UserDetails userDetails
+    );
+
+    @Operation(
+        summary = "신고/문의 전체 검색",
+        description = "상태, 유형, 신고자 등 조건별로 신고/문의 목록을 조회합니다. (페이징 지원, 관리자만 접근 가능)"
+    )
+    @ApiSuccessResponse(description = "목록 조회 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @GetMapping
+    ResponseEntity<ApiResponse<Page<DisputeDetailResponse>>> search(
+        @RequestParam(required=false) DisputeStatus status,
+        @RequestParam(required=false) DisputeType type,
+        @RequestParam(required=false) String reporter,
+        @RequestParam(defaultValue="0") int page,
+        @RequestParam(defaultValue="20") int size
+    );
+
+    @Operation(
+        summary = "처리 대기 신고/문의 목록",
+        description = "IN_PROGRESS 상태(진행 중) 신고/문의만 페이징 조회합니다."
+    )
+    @ApiSuccessResponse(description = "목록 조회 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @GetMapping("/pending")
+    ResponseEntity<ApiResponse<Page<DisputeDetailResponse>>> pending(
+        @RequestParam(defaultValue="0") int page,
+        @RequestParam(defaultValue="20") int size
+    );
+
+    @Operation(
+        summary = "신고/문의 상세 조회",
+        description = "특정 신고/문의의 상세 정보를 확인합니다."
+    )
+    @ApiSuccessResponse(description = "상세 조회 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
+    @GetMapping("/{id}")
+    ResponseEntity<ApiResponse<DisputeDetailResponse>> detailDispute(
+        @PathVariable Long id,
+        @AuthenticationPrincipal UserDetails userDetails
+    );
+
+    @Operation(
+        summary = "신고/문의 환불 및 거래취소",
+        description = "관리자가 답변 완료(ANSWERED) 상태의 신고/문의 건에 대해 환불 및 거래취소를 처리합니다."
+    )
+    @ApiSuccessResponse(description = "환불 및 거래취소 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
+    @PostMapping("/{id}/refund-and-cancel")
+    ResponseEntity<ApiResponse<Void>> refundAndCancel(
+        @PathVariable Long id,
+        @AuthenticationPrincipal UserDetails admin
+    );
+
+    @Operation(
+        summary = "판매자 패널티 부여",
+        description = "관리자가 신고/문의에 대해 판매자에게 패널티를 부여합니다."
+    )
+    @ApiSuccessResponse(description = "패널티 부여 성공")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
+    @PostMapping("/{id}/penalty-seller")
+    ResponseEntity<ApiResponse<Void>> penaltySeller(
+        @PathVariable Long id,
+        @AuthenticationPrincipal UserDetails admin
+    );
+
+    @Operation(
+        summary = "신고/문의 복구 시도",
+        description = "해당 거래에 활성(IN_PROGRESS/NEED_MORE) 신고가 0개면 거래를 원상복구합니다."
+    )
+    @ApiSuccessResponse(description = "복구 처리 결과 반환")
+    @ErrorCode401(description = "인증되지 않은 사용자")
+    @ErrorCode404(description = "신고(문의) 내역을 찾을 수 없음")
+    @PostMapping("/{id}/finalize")
+    ResponseEntity<ApiResponse<Void>> finalizeIfNoActive(
+        @PathVariable Long id,
+        @AuthenticationPrincipal UserDetails admin
+    );
+}

--- a/src/main/java/com/ureca/snac/trade/dto/DisputeSearchCond.java
+++ b/src/main/java/com/ureca/snac/trade/dto/DisputeSearchCond.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.dto;
 
+import com.ureca.snac.trade.entity.DisputeCategory;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
 import lombok.AllArgsConstructor;
@@ -15,4 +16,5 @@ public class DisputeSearchCond {
     private DisputeStatus status;
     private DisputeType type;
     private String reporter;
+    private DisputeCategory category;
 }

--- a/src/main/java/com/ureca/snac/trade/dto/dispute/DisputeDetailResponse.java
+++ b/src/main/java/com/ureca/snac/trade/dto/dispute/DisputeDetailResponse.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.dto.dispute;
 
+import com.ureca.snac.trade.entity.DisputeCategory;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class DisputeDetailResponse {
     private String title;
     private String description;
     private String answer;
+    private DisputeCategory category;
 
     private List<String> attachmentUrls;
     private LocalDateTime createdAt;

--- a/src/main/java/com/ureca/snac/trade/dto/dispute/MyDisputeListItemDto.java
+++ b/src/main/java/com/ureca/snac/trade/dto/dispute/MyDisputeListItemDto.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.dto.dispute;
 
+import com.ureca.snac.trade.entity.DisputeCategory;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ public class MyDisputeListItemDto {
     private DisputeType type;
     private String title;
     private String description;
+    private DisputeCategory category;
     private LocalDateTime createdAt;
     private LocalDateTime answerAt;
     private TradeSummaryDto trade;

--- a/src/main/java/com/ureca/snac/trade/entity/Dispute.java
+++ b/src/main/java/com/ureca/snac/trade/entity/Dispute.java
@@ -75,10 +75,10 @@ public class Dispute extends BaseTimeEntity {
         this.status     = DisputeStatus.ANSWERED;
     }
 
-    public void reject(String answer) {
-        this.answer   = answer;
-        this.answerAt = LocalDateTime.now();
-        this.status   = DisputeStatus.REJECTED;
-    }
+//    public void reject(String answer) {
+//        this.answer   = answer;
+//        this.answerAt = LocalDateTime.now();
+//        this.status   = DisputeStatus.REJECTED;
+//    }
 
 }

--- a/src/main/java/com/ureca/snac/trade/entity/Dispute.java
+++ b/src/main/java/com/ureca/snac/trade/entity/Dispute.java
@@ -48,11 +48,15 @@ public class Dispute extends BaseTimeEntity {
     @Column(name = "prev_trade_status", length = 20)
     private TradeStatus prevTradeStatus;  // 직전 Trade 상태 백업
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private DisputeCategory category;
+
     @Column(name = "reported_applied", nullable = false)
     private boolean reportedApplied; // 거래 상태 변경한 신고인가?
     @Builder
     public Dispute(String title, Trade trade, Member reporter, DisputeType type, String description,
-                   TradeStatus prevTradeStatus, boolean reportedApplied) {
+                   TradeStatus prevTradeStatus, boolean reportedApplied, DisputeCategory category) {
         this.title = title;
         this.trade = trade;
         this.reporter = reporter;
@@ -61,6 +65,7 @@ public class Dispute extends BaseTimeEntity {
         this.status = DisputeStatus.IN_PROGRESS;
         this.prevTradeStatus = prevTradeStatus;
         this.reportedApplied = reportedApplied;
+        this.category = category;
     }
 
     // 상태 변경

--- a/src/main/java/com/ureca/snac/trade/entity/DisputeAttachment.java
+++ b/src/main/java/com/ureca/snac/trade/entity/DisputeAttachment.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.trade.entity;
 
+import com.ureca.snac.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -7,7 +8,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "dispute_attachment")
-public class DisputeAttachment {
+public class DisputeAttachment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ureca/snac/trade/entity/DisputeCategory.java
+++ b/src/main/java/com/ureca/snac/trade/entity/DisputeCategory.java
@@ -1,0 +1,6 @@
+package com.ureca.snac.trade.entity;
+
+public enum DisputeCategory {
+    REPORT, // 거래 신고
+    QNA // 일반 문의
+}

--- a/src/main/java/com/ureca/snac/trade/entity/DisputeStatus.java
+++ b/src/main/java/com/ureca/snac/trade/entity/DisputeStatus.java
@@ -4,6 +4,6 @@ public enum DisputeStatus {
     IN_PROGRESS, // 접수 후 진행중
     ANSWERED, // 관리자 확정 답변
     NEED_MORE, // 자료 추가 요청
-    REJECTED // 기각!
+//    REJECTED // 기각!
 
 }

--- a/src/main/java/com/ureca/snac/trade/entity/DisputeType.java
+++ b/src/main/java/com/ureca/snac/trade/entity/DisputeType.java
@@ -6,5 +6,6 @@ public enum DisputeType {
     PAYMENT, // 결제 관련
     ACCOUNT, // 계정 관련
     TECHNICAL_PROBLEM, // 기술적 문제
-    OTHER // 기타
+    REPORT_OTHER, // 기타
+    QNA_OTHER // 기타
 }

--- a/src/main/java/com/ureca/snac/trade/repository/DisputeRepositoryImpl.java
+++ b/src/main/java/com/ureca/snac/trade/repository/DisputeRepositoryImpl.java
@@ -34,6 +34,10 @@ public class DisputeRepositoryImpl implements DisputeRepositoryCustom {
         if (hasText(cond.getReporter())) {
             booleanBuilder.and(qDispute.reporter.email.contains(cond.getReporter()));
         }
+        if (cond.getCategory() != null) {
+            booleanBuilder.and(qDispute.category.eq(cond.getCategory()));
+        }
+
 
 
         List<Dispute> content = qf.selectFrom(qDispute)

--- a/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
@@ -62,14 +62,13 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
                 dispute.needMore(dto.getAnswer()); // 답변 상태 갱신
                 // 자동확정은 안됨.. 고려해봐야 할 부분
             }
-            case REJECTED  -> { // 신고 기각
-                dispute.reject(dto.getAnswer());
-                //  trade.resumeAutoConfirm(); // 자동확정 재개
-
-                restoreTradeIfNoActive(trade);
-
-                // 환불 패널티 x
-            }
+//            case REJECTED  -> { // 신고 기각
+//                dispute.reject(dto.getAnswer());
+//
+//                restoreTradeIfNoActive(trade);
+//
+//                // 환불 패널티 x
+//            }
             case ANSWERED  -> {
                 dispute.answered(dto.getAnswer());
 
@@ -91,7 +90,7 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
 
 
     // 목록 조회
-    public Page<DisputeDetailResponse> list(DisputeSearchCond cond, Pageable page) {
+    public Page<DisputeDetailResponse> searchList(DisputeSearchCond cond, Pageable page) {
         /* repository.search(...) 가 Page<Dispute> 를 주면
            map(this::toDto) 로 DTO 변환, 페이징 정보는 그대로 유지 */
         return disputeRepository.search(cond, page)
@@ -182,7 +181,7 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
      *  - 반환값: true = 복구됨 / false = 스킵
      */
     @Override
-    public boolean finalizeIfNoActive(Long disputeId, String adminEmail) {
+    public boolean restoreIfNoActive(Long disputeId, String adminEmail) {
         assertAdmin(adminEmail);
 
         Dispute d = disputeRepository.findById(disputeId)

--- a/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
@@ -214,7 +214,7 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
 
         return new DisputeDetailResponse(
                 d.getId(), d.getStatus(), d.getType(), d.getTitle(),
-                d.getDescription(), d.getAnswer(),
+                d.getDescription(), d.getAnswer(), d.getCategory(),
                 urls, d.getCreatedAt(), d.getAnswerAt());
     }
 

--- a/src/main/java/com/ureca/snac/trade/service/DisputeServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeServiceImpl.java
@@ -69,6 +69,7 @@ public class DisputeServiceImpl implements DisputeService {
                         .description(description)
                         .prevTradeStatus(prev)
                         .reportedApplied(applied)
+                        .category(DisputeCategory.REPORT)
                         .build()
         );
 
@@ -100,6 +101,7 @@ public class DisputeServiceImpl implements DisputeService {
                 dispute.getTitle(),
                 dispute.getDescription(),
                 dispute.getAnswer(),
+                dispute.getCategory(),
                 urls,
                 dispute.getCreatedAt(),
                 dispute.getAnswerAt());
@@ -120,6 +122,7 @@ public class DisputeServiceImpl implements DisputeService {
                             dispute.getType(),
                             dispute.getTitle(),
                             dispute.getDescription(),
+                            dispute.getCategory(),
                             dispute.getCreatedAt(),
                             dispute.getAnswerAt(),
                             summary
@@ -171,6 +174,7 @@ public class DisputeServiceImpl implements DisputeService {
                         .description(description)
                         .prevTradeStatus(null)
                         .reportedApplied(false)
+                        .category(DisputeCategory.QNA)
                         .build()
         );
 

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/DisputeAdminService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/DisputeAdminService.java
@@ -9,10 +9,10 @@ import org.springframework.data.domain.Pageable;
 public interface DisputeAdminService {
     void answer(Long id, DisputeAnswerRequest dto, String adminEmail);
 
-    Page<DisputeDetailResponse> list(DisputeSearchCond cond, Pageable page);
+    Page<DisputeDetailResponse> searchList(DisputeSearchCond cond, Pageable page);
 
     // 관리 동작 분리
     void refundAndCancel(Long disputeId, String adminEmail);
     void givePenaltyToSeller(Long disputeId, String adminEmail);
-    boolean finalizeIfNoActive(Long disputeId, String adminEmail);
+    boolean restoreIfNoActive(Long disputeId, String adminEmail);
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 신고(문의) 관리자 기능 스웨거 작성했습니다.
2. 관리자 신고(문의) 처리 중 기각이 불필요 할 것 같아 제외했습니다.
3. dispute에 카테고리 필드를 추가했습니다.
4. 신고(문의) 검색 기능 추가

## 🔍 변경 사항 세부 설명

- 기각을 처리한 이유는 상태처리에서는 단순히 답변만 하며 이는 후처리를 하든 기각을 하든 동일합니다.
- 떄문에 기각을 제거하고 답변을 했다면 이후 패널티, 환불, 취소, 원상복구 등 관리자가 후처리기능을 통해 처리합니다.
- 신고만 고려하고 만들었던 엔티티이기 때문에 추가적으로 문의가 들어오며 구별하는데 불편함이 있었는데 카테고리 필드를 추가하여 구분할 수 있도록 했습니다.

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 