### PR TITLE
[feat] dispute 카테고리 별 타입 별 통계 기능 추가, 거래 조회 시 신고정보 불러오기

### DIFF
--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -300,6 +300,7 @@ public enum BaseCode {
     DISPUTE_CREATE_SUCCESS("DISPUTE_CREATE_SUCCESS_201", HttpStatus.CREATED, "신고가 접수되었습니다."),
     QNA_CREATE_SUCCESS("QNA_CREATE_SUCCESS_201", HttpStatus.CREATED, "문의가 접수되었습니다."),
     DISPUTE_DETAIL_SUCCESS("DISPUTE_DETAIL_SUCCESS_200", HttpStatus.OK, "신고 상세를 조회했습니다."),
+    DISPUTE_STAT_SUCCESS("DISPUTE_STAT_SUCCESS_200", HttpStatus.OK, "DISPUTE 타입별, 카테고리별 통계를 조회했습니다."),
     DISPUTE_COMMENT_SUCCESS("DISPUTE_COMMENT_SUCCESS_201", HttpStatus.CREATED, "신고 답변이 등록되었습니다."),
 
     DISPUTE_NEED_MORE("DISPUTE_NEED_MORE_200", HttpStatus.OK,"추가 자료 요청"),

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminController.java
@@ -5,6 +5,7 @@ import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.dto.dispute.DisputeStatisticsResponse;
 import com.ureca.snac.trade.entity.Dispute;
 import com.ureca.snac.trade.entity.DisputeCategory;
 import com.ureca.snac.trade.entity.DisputeStatus;
@@ -46,7 +47,7 @@ public class DisputeAdminController implements  DisputeAdminControllerSwagger{
         BaseCode baseCode = switch (disputeAnswerRequest.getResult()) {
             case NEED_MORE -> DISPUTE_NEED_MORE;
 //            case REJECTED  -> DISPUTE_REJECTED_SUCCESS;
-            default        -> DISPUTE_ANSWERED_SUCCESS;
+            default -> DISPUTE_ANSWERED_SUCCESS;
         };
 
         return ResponseEntity.ok(ApiResponse.ok(baseCode));
@@ -122,4 +123,9 @@ public class DisputeAdminController implements  DisputeAdminControllerSwagger{
         return ResponseEntity.ok(ApiResponse.ok(code));
     }
 
+    @GetMapping("/statistics")
+    public ResponseEntity<ApiResponse<DisputeStatisticsResponse>> statistics() {
+        DisputeStatisticsResponse statistics = disputeAdminService.getStatistics();
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.DISPUTE_STAT_SUCCESS, statistics));
+    }
 }

--- a/src/main/java/com/ureca/snac/trade/controller/DisputeAdminControllerSwagger.java
+++ b/src/main/java/com/ureca/snac/trade/controller/DisputeAdminControllerSwagger.java
@@ -9,6 +9,7 @@ import com.ureca.snac.swagger.annotation.response.ApiSuccessResponse;
 import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.dto.dispute.DisputeStatisticsResponse;
 import com.ureca.snac.trade.entity.DisputeStatus;
 import com.ureca.snac.trade.entity.DisputeType;
 import com.ureca.snac.trade.entity.DisputeCategory;
@@ -121,4 +122,12 @@ public interface DisputeAdminControllerSwagger {
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails admin
     );
+
+    @Operation(
+            summary = "신고/문의 통계 조회",
+            description = "카테고리별/타입별 신고 문의 건수 통계를 반환"
+    )
+    @ApiSuccessResponse(description = "통계 조회 성공")
+    @GetMapping("/statistics")
+    ResponseEntity<ApiResponse<DisputeStatisticsResponse>> statistics();
 }

--- a/src/main/java/com/ureca/snac/trade/dto/dispute/DisputeStatisticsResponse.java
+++ b/src/main/java/com/ureca/snac/trade/dto/dispute/DisputeStatisticsResponse.java
@@ -1,0 +1,15 @@
+package com.ureca.snac.trade.dto.dispute;
+
+import com.ureca.snac.trade.entity.DisputeCategory;
+import com.ureca.snac.trade.entity.DisputeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class DisputeStatisticsResponse {
+    private Map<DisputeCategory, Long> countByCategory;
+    private Map<DisputeType, Long> countByType;
+}

--- a/src/main/java/com/ureca/snac/trade/repository/DisputeRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/DisputeRepository.java
@@ -34,4 +34,9 @@ public interface DisputeRepository extends JpaRepository<Dispute, Long> , Disput
     """)
     Page<Dispute> findReceivedByParticipant(@Param("me") Member me, Pageable pageable);
 
+    @Query("SELECT d.category, COUNT(d) FROM Dispute d GROUP BY d.category")
+    List<Object[]> countGroupByCategory();
+
+    @Query("SELECT d.type, COUNT(d) FROM Dispute d GROUP BY d.type")
+    List<Object[]> countGroupByType();
 }

--- a/src/main/java/com/ureca/snac/trade/repository/TradeCancelRepository.java
+++ b/src/main/java/com/ureca/snac/trade/repository/TradeCancelRepository.java
@@ -42,6 +42,16 @@ public interface TradeCancelRepository extends JpaRepository<TradeCancel, Long> 
     """)
     List<TradeCancelSummary> findCancelSummaryByTradeIds(@Param("tradeIds") Collection<Long> tradeIds);
 
+    @Query("""
+    select tc.trade.id as tradeId,
+           tc.reason as reason,
+           tc.status as status,
+           tc.createdAt as createdAt
+      from TradeCancel tc
+     where tc.trade.id = :tradeId
+    """)
+    Optional<TradeCancelSummary> findSummaryByTradeId(@Param("tradeId") Long tradeId);
+
     interface TradeCancelSummary {
         Long getTradeId();
         com.ureca.snac.trade.entity.CancelReason getReason();

--- a/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
@@ -13,6 +13,7 @@ import com.ureca.snac.member.exception.MemberNotFoundException;
 import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.dto.dispute.DisputeStatisticsResponse;
 import com.ureca.snac.trade.entity.*;
 import com.ureca.snac.trade.exception.DisputeAdminPermissionDeniedException;
 import com.ureca.snac.trade.exception.DisputeNotFoundException;
@@ -30,7 +31,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -202,6 +206,31 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
 
         trade.resumeAutoConfirm();
         return true;
+    }
+
+    @Override
+    public DisputeStatisticsResponse getStatistics() {
+        // 카테고리별
+        Map<DisputeCategory, Long> byCategory = new HashMap<>();
+        List<Object[]> categoryList = disputeRepository.countGroupByCategory();
+
+        for (Object[] arr : categoryList) {
+            DisputeCategory category = (DisputeCategory) arr[0];
+            Long count = (Long) arr[1];
+            byCategory.put(category, count);
+        }
+
+        // 타입별
+        Map<DisputeType, Long> byType = new HashMap<>();
+        List<Object[]> typeList = disputeRepository.countGroupByType();
+
+        for (Object[] arr : typeList) {
+            DisputeType type = (DisputeType) arr[0];
+            Long count = (Long) arr[1];
+            byType.put(type, count);
+        }
+
+        return new DisputeStatisticsResponse(byCategory, byType);
     }
 
 

--- a/src/main/java/com/ureca/snac/trade/service/TradeQueryServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeQueryServiceImpl.java
@@ -172,8 +172,13 @@ public class TradeQueryServiceImpl implements TradeQueryService {
             isPartnerFavorite =
                     favoriteRepository.existsByFromMemberIdAndToMemberId(member.getId(), partnerId);
         }
+
+        TradeCancelRepository.TradeCancelSummary cancel =
+                tradeCancelRepository.findSummaryByTradeId(tradeId).orElse(null);
+
         return TradeResponse.from(
-                trade, username, isPartnerFavorite, null, partnerId, partnerNickname);
+                trade, username, isPartnerFavorite, cancel, partnerId, partnerNickname
+        );
     }
 
     @Override

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/DisputeAdminService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/DisputeAdminService.java
@@ -3,6 +3,7 @@ package com.ureca.snac.trade.service.interfaces;
 import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
+import com.ureca.snac.trade.dto.dispute.DisputeStatisticsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,4 +16,6 @@ public interface DisputeAdminService {
     void refundAndCancel(Long disputeId, String adminEmail);
     void givePenaltyToSeller(Long disputeId, String adminEmail);
     boolean restoreIfNoActive(Long disputeId, String adminEmail);
+
+    DisputeStatisticsResponse getStatistics();
 }


### PR DESCRIPTION
## 📝 변경 사항

1. 신고(문의)의 카테고리별 타입별 count를 볼 수 있도록 기능 추가했습니다.
2. 기존 거래 단건 조회 시 신고정보가 안나오던 문제가 있어 수정했습니다.

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 