### PR TITLE
fix: 분리된 트랜잭션과 이벤트 에러

### DIFF
--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
@@ -49,7 +49,7 @@ public class MoneyDepositor {
                 member.getId(), balanceAfter);
 
         AssetChangedEvent event = assetChangedEventFactory.createForRechargeEvent(
-                member.getId(), recharge.getId(), recharge.getPaidAmountWon(), balanceAfter
+                member.getId(), payment.getId(), recharge.getPaidAmountWon(), balanceAfter
         );
         assetHistoryEventPublisher.publish(event);
         log.info("[머니 입금 처리] 자산 변동 기록 이벤트 발행 완료.");


### PR DESCRIPTION
## 🔍 세부 설명

- 자산 변동 내역을 조회하는데 paymentKey 필드가 로컬 Swagger에서는 값이 잘 나오는데, 배포된 서버의 Swagger에서 테스트하면 null로 나온다.
- 이거 로컬은 동기적, 운영환경은 비동기적이라서!!!!!!!!!!!
