### PR TITLE
feat: 소셜 로그인 예외 처리 개선 및 에러 코드 추가

### DIFF
--- a/src/main/java/com/ureca/snac/auth/oauth2/CustomOAuth2FailHandler.java
+++ b/src/main/java/com/ureca/snac/auth/oauth2/CustomOAuth2FailHandler.java
@@ -5,12 +5,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2FailHandler implements AuthenticationFailureHandler {
@@ -19,6 +23,17 @@ public class CustomOAuth2FailHandler implements AuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        response.sendRedirect("https://snac-app.com/certification");
+        String errorCode = "unknown_error";
+        if (exception instanceof OAuth2AuthenticationException oauthEx && oauthEx.getError() != null) {
+            errorCode = oauthEx.getError().getErrorCode();
+        }
+
+        log.info("errorCode={}", errorCode);
+        String redirectUrl = UriComponentsBuilder.fromUriString("https://snac-app.com/certification")
+                .queryParam("error", errorCode)
+                .build().toUriString();
+
+        log.info("redirectUrl={}", redirectUrl);
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/ureca/snac/common/BaseCode.java
+++ b/src/main/java/com/ureca/snac/common/BaseCode.java
@@ -30,8 +30,10 @@ public enum BaseCode {
     OAUTH_LOGIN_SUCCESS("OAUTH_LOGIN_SUCCESS_200", HttpStatus.OK, "소셜 로그인에 성공했습니다."),
 
     // 소셜 로그인 시도 - 실패
-    OAUTH_LOGIN_FAILED("OAUTH_LOGIN_FAILED_401", HttpStatus.UNAUTHORIZED, "회원이 아니거나, 소셜 연동이 되어 있지 않습니다."),
     UNSUPPORTED_SOCIAL_PROVIDER("UNSUPPORTED_SOCIAL_PROVIDER_400", HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 프로바이더입니다."),
+
+    OAUTH_DB_ALREADY_LINKED("OAUTH_DB_ALREADY_LINKED_409", HttpStatus.CONFLICT, "이미 다른 계정에 연동된 소셜 계정입니다."),
+    OAUTH_DB_ACCOUNT_NOT_FOUND("OAUTH_DB_ACCOUNT_NOT_FOUND_404", HttpStatus.NOT_FOUND, "소셜 계정에 연동된 계정이 없습니다. 회원가입을 먼저 진행해주세요."),
 
     // 카카오 연동 해제 관련
     KAKAO_UNLINK_SUCCESS("KAKAO_UNLINK_SUCCESS_200", HttpStatus.OK, "카카오 연결 끊기에 성공했습니다."),


### PR DESCRIPTION
## 📝 변경 사항

소셜 로그인 예외 처리 개선 및 에러 코드 추가



## 🔍 변경 사항 세부 설명

- 새로운 에러 코드 추가 (`OAUTH_DB_ALREADY_LINKED`, `OAUTH_DB_ACCOUNT_NOT_FOUND`)
- 소셜 로그인 시 이미 연동된 계정, 미연동 계정 예외에 대해 명확한 에러 메시지 처리
- `CustomOAuth2FailHandler`에서 실패 시 에러 코드 파라미터를 포함하여 리디렉션 처리 추가
- 로그 메시지 및 예외 처리 로직 개선으로 디버깅 효율성 향상

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 