### PR TITLE
[feat] 판매자가 구매자 취소요청 기각 후 판매자 취소요청 가능하게 수정

### DIFF
--- a/src/main/java/com/ureca/snac/trade/entity/TradeCancel.java
+++ b/src/main/java/com/ureca/snac/trade/entity/TradeCancel.java
@@ -45,6 +45,14 @@ public class TradeCancel extends BaseTimeEntity {
         this.resolvedAt = LocalDateTime.now();
     }
 
+    // 판매자에 의한 취소로 업데이트
+    public void updateBySellerCancel(Member seller, CancelReason reason) {
+        this.requester = seller;
+        this.reason = reason;
+        this.status = CancelStatus.ACCEPTED;
+        this.resolvedAt = LocalDateTime.now();
+    }
+
     @Builder
     public TradeCancel(Trade trade, Member requester, CancelReason reason, CancelStatus status, LocalDateTime resolvedAt) {
         this.trade = trade;

--- a/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
@@ -102,24 +102,25 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
     }
 
     // 관리자 답변 처리 후 , 활성 신고가 없으면 원상복구
-    private void restoreTradeIfNoActive(Trade trade) {
-        boolean hasActive = disputeRepository.existsByTradeIdAndStatusIn(trade.getId(), ACTIVE);
-        if (hasActive) return;
-
-        // REPORTED 로 만든 신고를 찾아 그때 백업했던 상태로 복귀
-        disputeRepository.findTopByTradeIdAndReportedAppliedTrueOrderByCreatedAtAsc(trade.getId())
-                .ifPresent(marker -> {
-                    TradeStatus prev = marker.getPrevTradeStatus();
-                    if (prev != null) {
-                        trade.changeStatus(prev);
-                    } else {
-                        //  신고는 DATA_SENT 이후에 가능하므로 DATA_SENT로 복원
-                        trade.changeStatus(TradeStatus.DATA_SENT);
-                    }
-                });
-
-        trade.resumeAutoConfirm(); // 자동 확정 재개
-    }
+//    private void restoreTradeIfNoActive(Trade trade) {
+//
+//        boolean hasActive = disputeRepository.existsByTradeIdAndStatusIn(trade.getId(), ACTIVE);
+//        if (hasActive) return;
+//
+//        // REPORTED 로 만든 신고를 찾아 그때 백업했던 상태로 복귀
+//        disputeRepository.findTopByTradeIdAndReportedAppliedTrueOrderByCreatedAtAsc(trade.getId())
+//                .ifPresent(marker -> {
+//                    TradeStatus prev = marker.getPrevTradeStatus();
+//                    if (prev != null) {
+//                        trade.changeStatus(prev);
+//                    } else {
+//                        //  신고는 DATA_SENT 이후에 가능하므로 DATA_SENT로 복원
+//                        trade.changeStatus(TradeStatus.DATA_SENT);
+//                    }
+//                });
+//
+//        trade.resumeAutoConfirm(); // 자동 확정 재개
+//    }
 
     /** 환불 + 거래 취소 + 자동확정 재개
      *    1) ANSWERED 상태의 Dispute 에서만 수행 (권한·검증 명확)
@@ -192,7 +193,7 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
                 .orElseThrow(DisputeNotFoundException::new);
 
         Trade trade = d.getTrade();
-
+        // 처리 안된 dispute 가 있는 확인
         boolean hasActive = disputeRepository.existsByTradeIdAndStatusIn(
                 trade.getId(), ACTIVE);
         if (hasActive) return false;


### PR DESCRIPTION

## 📝 변경 사항

- 기존에 판매자가 구매자의 취소요청을 기각하면 판매자가 다시 취소요청이 불가했던 문제를 수정했습니다

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 